### PR TITLE
Surface errors correctly

### DIFF
--- a/createWebpackBundle.js
+++ b/createWebpackBundle.js
@@ -1,4 +1,3 @@
-/* eslint-enable no-console */
 const webpack = require('webpack');
 const path = require('path');
 const fs = require('fs');

--- a/createWebpackBundle.js
+++ b/createWebpackBundle.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-enable no-console */
 const webpack = require('webpack');
 const path = require('path');
 const fs = require('fs');
@@ -138,13 +138,18 @@ function createWebpackBundle(logger, fractalComponents, watch = true) {
   });
 
   if (watch) {
-    compiler.watch({}, (err, info) => {
-      logger.update(info, 'info');
+    compiler.watch({}, (err, stats) => {
+      if (err || stats.hasErrors()) {
+        const info = stats.toJson();
+        logger.error(info.errors);
+      }
     });
   } else {
-    compiler.run((err) => {
-      if (err) {
-        logger.error(err);
+    compiler.run((err, stats) => {
+      if (err || stats.hasErrors()) {
+        const info = stats.toJson();
+        logger.error(info.errors);
+        throw new Error('Webpack compilation error');
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "export-components": "node src/js/export-components.js",
     "start": "fractal watch",
     "test": "karma start --single-run",
-    "site": "fractal build-site; gh-pages -d build",
+    "site": "fractal build-site && gh-pages -d build",
     "test-watch": "karma start --auto-watch",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",
     "test-debug": "karma start --browsers Chrome"


### PR DESCRIPTION
These changes make it so Webpack and build errors are shown in the console and cause the commands to exit with an error code. This will make adding a Jenkins build process smoother.