### PR TITLE
add errorable radio button and its dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-docgen": "^2.19.0",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.5.0",
+    "react-transition-group": "^1.1.2",
     "resolve-url-loader": "^2.2.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/src/components/errorable_radio_buttons/ErrorableRadioButtons.jsx
+++ b/src/components/errorable_radio_buttons/ErrorableRadioButtons.jsx
@@ -1,0 +1,198 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import _ from 'lodash';
+import classNames from 'classnames';
+
+import ToolTip from '../tooltip/Tooltip';
+import ExpandingGroup from '../expanding_group/ExpandingGroup';
+
+import { makeField } from '../../model/fields.js';
+
+/**
+ * A radio button group with a label.
+ *
+ * Validation has the following props.
+
+ * `additionalFieldsetClass` - String for any additional fieldset classes.
+ * `additionalLegendClass` - String for any additional legend classes.
+ * `label` - String for the group field label.
+ * `name` - String for the name attribute.
+ * `toolTipText` - String with help text for user.
+ * `tabIndex` - Number for keyboard tab order.
+ * `options` - Array of options to populate group.
+ * `required` - is this field required.
+ * `value` - string. Value of the select field.
+ * `onValueChange` - a function with this prototype: (newValue)
+ */
+class ErrorableRadioButtons extends React.Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+    this.getMatchingSubSection = this.getMatchingSubSection.bind(this);
+  }
+
+  componentWillMount() {
+    this.inputId = this.props.id || _.uniqueId('errorable-radio-buttons-');
+  }
+
+  getMatchingSubSection(checked, optionValue) {
+    if (checked && this.props.children) {
+      const children = _.isArray(this.props.children) ? this.props.children : [this.props.children];
+      const subsections = children.filter((child) => child.props.showIfValueChosen === optionValue);
+      return subsections.length > 0 ? subsections[0] : null;
+    }
+
+    return null;
+  }
+
+  handleChange(domEvent) {
+    this.props.onValueChange(makeField(domEvent.target.value, true));
+  }
+
+  render() {
+    // TODO: extract error logic into a utility function
+    // Calculate error state.
+    let errorSpan = '';
+    let errorSpanId = undefined;
+    if (this.props.errorMessage) {
+      errorSpanId = `${this.inputId}-error-message`;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
+    }
+
+    // Addes ToolTip if text is provided.
+    let toolTip;
+    if (this.props.toolTipText) {
+      toolTip = (
+        <ToolTip
+          tabIndex={this.props.tabIndex}
+          toolTipText={this.props.toolTipText}/>
+      );
+    }
+
+    // Calculate required.
+    let requiredSpan = undefined;
+    if (this.props.required) {
+      requiredSpan = <span className="form-required-span">*</span>;
+    }
+
+    const options = _.isArray(this.props.options) ? this.props.options : [];
+    const storedValue = this.props.value.value;
+    const optionElements = options.map((obj, index) => {
+      let optionLabel;
+      let optionValue;
+      let optionAdditional;
+      if (_.isString(obj)) {
+        optionLabel = obj;
+        optionValue = obj;
+      } else {
+        optionLabel = obj.label;
+        optionValue = obj.value;
+        if (obj.additional) {
+          optionAdditional = (<div>{obj.additional}</div>);
+        }
+      }
+      const checked = optionValue === storedValue ? 'checked=true' : '';
+      const matchingSubSection = this.getMatchingSubSection(optionValue === storedValue, optionValue);
+      const radioButton = (
+        <div key={optionAdditional ? undefined : index} className="form-radio-buttons">
+          <input
+            autoComplete="false"
+            checked={checked}
+            id={`${this.inputId}-${index}`}
+            name={this.props.name}
+            type="radio"
+            value={optionValue}
+            onChange={this.handleChange}/>
+          <label
+            name={`${this.props.name}-${index}-label`}
+            htmlFor={`${this.inputId}-${index}`}>
+            {optionLabel}
+          </label>
+          {matchingSubSection}
+        </div>
+      );
+
+      let output = radioButton;
+
+      // Return an expanding group for buttons with additional content
+      if (optionAdditional) {
+        output = (
+          <ExpandingGroup
+            additionalClass="form-expanding-group-active-radio"
+            open={checked}
+            key={index}>
+            {radioButton}
+            <div>{optionAdditional}</div>
+          </ExpandingGroup>
+        );
+      }
+
+      return output;
+    });
+
+    const fieldsetClass = classNames('fieldset-input', {
+      'usa-input-error': this.props.errorMessage,
+      [this.props.additionalFieldsetClass]: this.props.additionalFieldsetClass
+    });
+
+    const legendClass = classNames('legend-label', {
+      'usa-input-error-label': this.props.errorMessage,
+      [this.props.additionalLegendClass]: this.props.additionalLegendClass
+    });
+
+    return (
+      <fieldset className={fieldsetClass}>
+        <legend
+          className={legendClass}>
+          {this.props.label}
+          {requiredSpan}
+        </legend>
+        {errorSpan}
+        {optionElements}
+        {toolTip}
+      </fieldset>
+    );
+  }
+}
+
+ErrorableRadioButtons.propTypes = {
+  additionalFieldsetClass: PropTypes.string,
+  additionalLegendClass: PropTypes.string,
+  errorMessage: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+  ]).isRequired,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  options: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        label: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element,
+        ]),
+        value: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.bool
+        ]),
+        additional: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element
+        ])
+      })
+    ])).isRequired,
+  value: PropTypes.shape({
+    value: PropTypes.string,
+    dirty: PropTypes.bool
+  }).isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  required: PropTypes.bool,
+};
+
+export default ErrorableRadioButtons;

--- a/src/components/errorable_radio_buttons/ErrorableRadioButtons.unit.spec.jsx
+++ b/src/components/errorable_radio_buttons/ErrorableRadioButtons.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import ErrorableRadioButtons from '../../../../src/js/common/components/form-elements/ErrorableRadioButtons';
+import { makeField } from '../../../../src/js/common/model/fields';
+
+describe('<ErrorableRadioButtons>', () => {
+  const options = [{ value: 'yes', label: 'Yes' }, { value: 'no', label: 'No' }];
+
+  it('ensure value changes propagate', (done) => {
+    let myRadioButtons;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      myRadioButtons = ReactTestUtils.renderIntoDocument(
+        <ErrorableRadioButtons label="test" options={options} value={makeField('test')} onValueChange={(update) => { resolve(update); }}/>
+      );
+      done();
+    });
+
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(myRadioButtons, 'input');
+    ReactTestUtils.Simulate.click(inputs[0]);
+
+    return expect(updatePromise).to.eventually.eql('Yes');
+  });
+
+  it('label attribute propagates', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableRadioButtons label="my label" options={options} value={makeField('test')} onValueChange={(_update) => {}}/>);
+
+    // Ensure label text is correct.
+    expect(tree.subTree('legend').text()).to.equal('my label');
+
+    // Ensure label htmlFor is attached to label id.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(2);
+    expect(inputs[0].props.id).to.not.be.undefined;
+    expect(inputs[0].props.id).to.equal(tree.everySubTree('label')[0].props.htmlFor);
+  });
+});

--- a/src/components/errorable_radio_buttons/errorable_radio_buttons.config.yml
+++ b/src/components/errorable_radio_buttons/errorable_radio_buttons.config.yml
@@ -1,0 +1,18 @@
+label: ErrorableRadioButtons
+status: wip
+
+context:
+  componentSourcePath: './ErrorableRadioButtons.jsx'
+  id: default
+  errorMessage: 'Radio Button errorMessage'
+  label: 'Errorable Radio Buttons'
+  options:
+    - 'option 1'
+    - 'option 2'
+    - label: 'option 3 label'
+      value: 'option 3 value'
+      addtional: 'option 3 addtional'
+  value:
+    - value: 'option 2'
+    - dirty: false
+  required: false

--- a/src/components/errorable_radio_buttons/errorable_radio_buttons.njk
+++ b/src/components/errorable_radio_buttons/errorable_radio_buttons.njk
@@ -1,0 +1,10 @@
+import React from 'react';
+import ErrorableRadioButtons from './ErrorableRadioButtons';
+
+export default function ErrorableRadioButtonsExample(props) {
+  return (
+          <ErrorableRadioButtons
+            onValueChange={({value}) => { console.log(value);}}
+            {...props}/>
+  );
+}

--- a/src/components/expanding_group/ExpandingGroup.jsx
+++ b/src/components/expanding_group/ExpandingGroup.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import classnames from 'classnames';
+
+/*
+ * Component that expands to show a hidden child element with a fade in/slide down animation
+ *
+ * Props:
+ * children - expects 2 children, the first is always shown, the second is shown if open is true
+ * open - determines if the second child is displayed
+ * additionalClass - A string added as a class to the parent element of the second child
+ * showPlus - Boolean to display a "+" or "-" icon based on open status
+ */
+export default function ExpandingGroup({ children, open, showPlus, additionalClass, expandedContentId }) {
+  const classNames = classnames(
+    'form-expanding-group',
+    { 'form-expanding-group-open': open },
+    { 'form-expanding-group-plus': showPlus }
+  );
+
+  return (
+    <div className={classNames}>
+      {children[0]}
+      <ReactCSSTransitionGroup id={expandedContentId} transitionName="form-expanding-group-inner" transitionEnterTimeout={700} transitionLeave={false}>
+        {open
+          ? <div key="removable-group" className={additionalClass}>
+            {children[1]}
+          </div>
+          : null}
+      </ReactCSSTransitionGroup>
+    </div>
+  );
+}
+
+ExpandingGroup.propTypes = {
+  open: PropTypes.bool.isRequired,
+  additionalClass: PropTypes.string,
+  showPlus: PropTypes.bool,
+  expandedContentId: PropTypes.string
+};

--- a/src/components/expanding_group/ExpandingGroup.unit.spec.jsx
+++ b/src/components/expanding_group/ExpandingGroup.unit.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import ExpandingGroup from '../../../../src/js/common/components/form-elements/ExpandingGroup';
+
+
+describe('<ExpandingGroup>', () => {
+  it('has sane looking features', () => {
+    const tree = SkinDeep.shallowRender(<ExpandingGroup open><first/><second/></ExpandingGroup>);
+    expect(tree.everySubTree('first')).to.have.lengthOf(1);
+    expect(tree.everySubTree('second')).to.have.lengthOf(1);
+  });
+
+  it('hides second child when closed', () => {
+    const tree = SkinDeep.shallowRender(<ExpandingGroup><first/><second/></ExpandingGroup>);
+    expect(tree.everySubTree('first')).to.have.lengthOf(1);
+    expect(tree.everySubTree('second')).to.have.lengthOf(0);
+  });
+});

--- a/src/components/expanding_group/expanding_group.config.yml
+++ b/src/components/expanding_group/expanding_group.config.yml
@@ -1,0 +1,9 @@
+label: ExpandingGroup
+status: wip
+notes: Expects two child components.
+
+context:
+  componentSourcePath: './ExpandingGroup.jsx'
+  open: false
+  key: 5
+  showPlus: true

--- a/src/components/expanding_group/expanding_group.njk
+++ b/src/components/expanding_group/expanding_group.njk
@@ -1,0 +1,12 @@
+import React from 'react';
+import ExpandingGroup from './ExpandingGroup';
+
+export default function ExpandingGroupExample(props) {
+  return (
+          <ExpandingGroup
+            {...props}>
+            <div>visible child</div>
+            <div>hidden child</div>
+          </ExpandingGroup>
+  );
+}

--- a/src/model/fields.js
+++ b/src/model/fields.js
@@ -1,0 +1,28 @@
+import _ from 'lodash';
+
+/**
+ * Represents an input field value.
+ *
+ * Input fields need to have a `dirty` state that represents whether or not a user has touched it.
+ * Without this state, it is extremely hard (impossible?) to write UI with required fields where
+ * the initial empty state does not get marked as a distracting error.
+ */
+export function makeField(value, optionalDirty) {
+  const dirty = optionalDirty === undefined ? false : optionalDirty;
+  return { value, dirty };
+}
+
+/**
+ * Walks through an object hierarchy of fields and marks everything dirty.
+ */
+export function dirtyAllFields(field) {
+  if (_.keys(field).length === 2 && _.has(field, 'value') && _.has(field, 'dirty')) {
+    return makeField(field.value, true);
+  } else if (_.isPlainObject(field)) {
+    return _.mapValues(field, (value, _k) => { return dirtyAllFields(value); });
+  } else if (_.isArray(field)) {
+    return field.map(dirtyAllFields);
+  }
+
+  return field;
+}


### PR DESCRIPTION
<img width="669" alt="screen shot 2018-01-22 at 09 10 31" src="https://user-images.githubusercontent.com/4998130/35227654-3cf6ff4e-ff54-11e7-9ce4-18a55282ddc2.png">
<img width="674" alt="screen shot 2018-01-22 at 09 10 44" src="https://user-images.githubusercontent.com/4998130/35227655-3d55d028-ff54-11e7-9897-cf15f7921fc7.png">
Pushing what I have so far. Both are tagged WIP in the design system.

I added ExpandingGroup and a helper from the website to fulfill ErrorableRadioButtons dependencies. 

I was unable to get any of the js dependent interactions to work on the local version but I think this is working as intended. LMK if I need to do something differently.