### PR TITLE
restored entry for fractal scss in Webpack

### DIFF
--- a/createWebpackBundle.js
+++ b/createWebpackBundle.js
@@ -28,12 +28,13 @@ function createWebpackBundle(logger, fractalComponents, watch = true) {
   fs.writeFileSync('./fractalEntry.js', output);
 
   const componentCSS = new ExtractTextPlugin('[name].css');
-  const fractalCSS = new ExtractTextPlugin('fractal.css');
+  const fractalCSS = new ExtractTextPlugin('[name]-styles.css');
 
   const compiler = webpack({
     entry: {
       components: './fractalEntry.js',
-      styles: './sass/site.scss'
+      styles: './sass/site.scss',
+      fractal: './sass/style.fractal.scss'
     },
     output: {
       filename: '[name].bundle.js',

--- a/fractal.js
+++ b/fractal.js
@@ -77,7 +77,7 @@ const theme = require('@frctl/mandelbrot')({
   ],
   styles: [
     'default',
-    '/fractal.css'
+    '/fractal-styles.css'
   ],
 });
 


### PR DESCRIPTION
Without the entry point changing the filename breaks the UI