### PR TITLE
[10019-breadcrumb-styles] Moving from the Vets.gov website into design-system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/jean-pants",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.config.yml
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.config.yml
@@ -6,4 +6,5 @@ context:
   componentSourcePath: './Breadcrumbs.jsx'
   crumbs: [{link: '#1', key: 'key1', label: 'link1'},
   {link: '#2', key: 'key2', label: 'link2'},
-  {link: '#3', key: 'key3', label: 'link3'}]
+  {link: '#3', key: 'key3', label: 'link3', ariaCurrent: true}]
+  id: 'va-breadcrumbs'

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
@@ -3,24 +3,35 @@ import React from 'react';
 
 class Breadcrumbs extends React.Component {
   render() {
-    const crumbs = this.props.crumbs;
+    const { crumbs, id } = this.props;
     return (
-      <nav className="va-nav-breadcrumbs">
-        <ul className="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
-          {crumbs.map((c) => {
-            return <li key={c.key}><a href={c.link}>{c.label}</a></li>;
+      <nav
+        aria-label="Breadcrumb"
+        className="va-nav-breadcrumbs"
+        id={id}>
+        <ol className="row va-nav-breadcrumbs-list columns" id={`${id}-list`}>
+          {crumbs.map(c => {
+            return (
+              <li key={c.key}>
+                <a
+                  aria-current={c.ariaCurrent ? 'page' : null}
+                  href={c.link}>
+                  {c.label}
+                </a>
+              </li>
+            );
           })}
-        </ul>
+        </ol>
       </nav>
     );
   }
 }
 
 Breadcrumbs.propTypes = {
-
   // array should contain objects that contain each breadcrumb's
   // key, href, and plain-text label
-  crumbs: PropTypes.arrayOf(PropTypes.object).isRequired
+  crumbs: PropTypes.arrayOf(PropTypes.object).isRequired,
+  id: PropTypes.string
 };
 
 export default Breadcrumbs;

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
@@ -31,6 +31,9 @@ Breadcrumbs.propTypes = {
   // array should contain objects that contain each breadcrumb's
   // key, href, and plain-text label
   crumbs: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // Passing a prop `id='STRING'` into the `<Breadcrumb>` component
+  // will append that ID to the `<nav>` element, and concatenate the
+  // ID plus `-list` to the `<ol>` element.
   id: PropTypes.string
 };
 

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.njk
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.njk
@@ -4,6 +4,7 @@ import Breadcrumbs from './Breadcrumbs';
 export default function BreadcrumbsExample(props) {
   return (
     <Breadcrumbs
+      id={props.id}
       includeSearch={props.includeSearch}
       crumbs={props.crumbs}/>
   );

--- a/src/components/navigation/Breadcrumbs/README.md
+++ b/src/components/navigation/Breadcrumbs/README.md
@@ -1,0 +1,17 @@
+## Intent
+
+Breadcrumbs are intended to provide users an understanding of where their are located in a rich information structure. They work well in situations where users may have clicked several layers deep, and would want to move back toward the top in linear steps.
+
+## Optional Attributes
+
+### aria-current (attribute)
+
+Passing an `ariaCurrent: true` key-value pair into the last `crumbs` object will trigger the `a[aria-current="page"]` CSS selector. This will make the last breadcrumb link bold, remove the underline, and change to a black text color. Current [WAI-ARIA authoring practices](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/breadcrumb/index.html) recommend an `aria-current="page"` attribute for screen reader context.
+
+### Id (prop)
+
+Passing a prop `id='STRING'` into the `<Breadcrumb>` component will append that ID to the `<nav>` element, and concatenate the ID plus `-list` to the `<ol>` element.
+
+### mobile link (CSS)
+
+If you want to provide a mobile-first, one-step at a time breadcrumb for smaller screens, you can apply the class `.va-nav-breadcrumbs-list__mobile-link` to a secondary breadcrumb link. This mobile-first experience will require a custom script to either hide the desktop breadcrumb, or replace it with a list tailored to mobile screens.

--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -43,21 +43,21 @@
     text-decoration: underline;
     background-color: $color-link-default-hover !important;
     -webkit-transition-duration: 0.3s;
-            transition-duration: 0.3s;
+    transition-duration: 0.3s;
 
     -webkit-transition-timing-function: ease-in-out;
-            transition-timing-function: ease-in-out;
+    transition-timing-function: ease-in-out;
 
     // Transition only these properties.
     -webkit-transition-property: color, background-color, border-color;
-            transition-property: color, background-color, border-color;
+    transition-property: color, background-color, border-color;
   }
   &:active {
     background: $color-link-default-hover;
   }
   &:focus {
-		outline: 2px dotted $color-gray-light;
-		outline-offset: 3px;
+    outline: 2px dotted $color-gray-light;
+    outline-offset: 3px;
   }
 }
 
@@ -73,4 +73,14 @@
 
 .clickable:hover {
   cursor: pointer;
+}
+
+// These are JavaScript only styles that will be added and removed
+// dynamically with scripts
+.js-visual {
+  visibility: hidden !important;
+}
+
+.js-hide {
+  display: none !important;
 }

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -621,9 +621,11 @@ ol {
       display: inline-block;
       padding: 0 0.35em;
     }
+
     &:last-child:after {
       content: "";
     }
+
     &.active {
       font-weight: bold;
       padding: 0.3em 0;
@@ -633,6 +635,7 @@ ol {
       }
     }
   }
+
   a {
     color: $color-link-default;
     display: inline-block;
@@ -642,11 +645,27 @@ ol {
       background: $color-link-default-hover;
     }
   }
+
+  a[aria-current="page"] {
+    color: $color-gray-dark !important;
+    cursor: default;
+    font-weight: bold;
+    pointer-events: none;
+    text-decoration: none;
+  }
 }
 
 .va-nav-breadcrumbs-list {
-  float: none;
+  float: none !important;
   position: relative;
+}
+
+.va-nav-breadcrumbs-list__mobile-link {
+  &::before {
+    content: " \2039 ";
+    display: inline-block;
+    padding: 0 0.15em;
+  }
 }
 
 //===== Playbook and Facility Locator
@@ -1476,4 +1495,3 @@ p.info-message {
     color: #fff;
   }
 }
-


### PR DESCRIPTION
First commit, adding breadcrumb styles and markup from Vets.gov website. These include all of the styles and adjustments needed to duplicate a breadcrumb list, show/hide. This is the CSS only, the JS should be project-specific.

This issue is a dependency to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6083. I will not look to merge that one until this is merged and available.