### PR TITLE
hotfix/7724: fix for radiobox issue with none component radioboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/form/controls/ErrorableRadioButtons/ErrorableRadioButtons.jsx
+++ b/src/components/form/controls/ErrorableRadioButtons/ErrorableRadioButtons.jsx
@@ -98,7 +98,7 @@ class ErrorableRadioButtons extends React.Component {
         <div
           key={optionAdditional ? undefined : optionIndex}
           className="form-radio-buttons">
-          <div className="errable-radio-button">
+          <div className="errorable-radio-button">
             <input
               autoComplete="false"
               checked={checked}

--- a/src/components/form/controls/ErrorableRadioButtons/ErrorableRadioButtons.jsx
+++ b/src/components/form/controls/ErrorableRadioButtons/ErrorableRadioButtons.jsx
@@ -98,7 +98,7 @@ class ErrorableRadioButtons extends React.Component {
         <div
           key={optionAdditional ? undefined : optionIndex}
           className="form-radio-buttons">
-          <div>
+          <div className="errable-radio-button">
             <input
               autoComplete="false"
               checked={checked}

--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -1,10 +1,6 @@
 .form-radio-buttons {
   label {
     margin-top: 1em;
-    outline: none;
-    padding: 6px 12px;
-    display: inline-block;
-    margin: 0;
 
     // Make links in radio button labels clickable
     a {
@@ -12,9 +8,18 @@
     }
   }
 
-  input:focus {
-    &+label {
-      background: #fad980;
+  .errable-radio-button {
+    label {
+      outline: none;
+      padding: 6px 12px;
+      display: inline-block;
+      margin: 0;
+    }
+
+    input:focus {
+      &+label {
+        background: #fad980;
+      }
     }
   }
 }

--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -8,7 +8,7 @@
     }
   }
 
-  .errable-radio-button {
+  .errorable-radio-button {
     label {
       outline: none;
       padding: 6px 12px;


### PR DESCRIPTION
This is a fix for none component radio button not working due to positioning issues.

How to test:

ErrorableRadioButton should still look like this on focus.
<img width="552" alt="screen shot 2018-05-14 at 2 07 23 pm" src="https://user-images.githubusercontent.com/5377648/40023570-57eeb6f0-5780-11e8-817c-0d72bfc80164.png">

On vets-website the radio buttons should be selectable and working. Also it should not have the yellow highlight. Use this link to check the radio button form.

http://localhost:3001/health-care/apply/application/household-information/financial-disclosure?skip

This is what it should look like now:
<img width="567" alt="screen shot 2018-05-14 at 2 09 58 pm" src="https://user-images.githubusercontent.com/5377648/40023612-8542360e-5780-11e8-8857-5c82e817bb57.png">
