### PR TITLE
Update primary color to avoid aXe issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/design-system.git"
   },
-  "main": "dist/jeanpants",
+  "main": "dist/formation",
   "scripts": {
     "prestart": "node prebuild.js",
     "export-components": "node ./scripts/build-node-modules.js",

--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -31,6 +31,8 @@ $site-max-width:      100rem; // Worksout to about 1000px. USWDS value is 1040px
 //===================================
 
 $color-base:                 #212121;
+$color-blue:                 #0071BB;
+$color-primary:              $color-blue;
 $color-primary-darker:       #003E73;
 $color-primary-darkest:      #112e51;
 $color-secondary-darkest:    #981b1e;


### PR DESCRIPTION
Our saved application status widget is generating an aXe error:

![screen shot 2018-05-16 at 11 33 36 am](https://user-images.githubusercontent.com/634932/40132473-e4ec4de8-590a-11e8-98d6-5a0c6a3d3cf1.png)

![screen shot 2018-05-16 at 1 12 32 pm](https://user-images.githubusercontent.com/634932/40132480-e96ebc0c-590a-11e8-8d59-95810aa07914.png)

This change very slightly tweaks the primary color to get above the WCAG threshold. I can't tell a difference visually. The changed color passes the contrast check: https://snook.ca/technical/colour_contrast/colour.html#fg=0071BB,bg=E1F3F8