### PR TITLE
Fix Modal TypeError

### DIFF
--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -40,7 +40,9 @@ class Modal extends React.Component {
     } else if (!newProps.visible && this.props.visible) {
       document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
       document.removeEventListener('focus', this.state.focusListener, true);
-      this.state.lastFocus.focus();
+      if (this.state.lastFocus) {
+        this.state.lastFocus.focus(); 
+      }
       document.body.classList.remove('modal-open');
     }
   }

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -43,7 +43,7 @@ class Modal extends React.Component {
     } else if (!newProps.visible && this.props.visible) {
       document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
       document.removeEventListener('focus', this.state.focusListener, true);
-      this.state.lastFocus.focus(); 
+      this.state.lastFocus.focus();
       document.body.classList.remove('modal-open');
     }
   }

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -24,7 +24,10 @@ class Modal extends React.Component {
     super(props);
     this.handleClose = this.handleClose.bind(this);
     this.handleDocumentKeyUp = this.handleDocumentKeyUp.bind(this);
-    this.state = { lastFocus: null, focusListener: null };
+    this.state = { 
+      lastFocus: document.activeElement, 
+      focusListener: null 
+    };
   }
 
   componentDidMount() {
@@ -40,9 +43,7 @@ class Modal extends React.Component {
     } else if (!newProps.visible && this.props.visible) {
       document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
       document.removeEventListener('focus', this.state.focusListener, true);
-      if (this.state.lastFocus) {
-        this.state.lastFocus.focus(); 
-      }
+      this.state.lastFocus.focus(); 
       document.body.classList.remove('modal-open');
     }
   }

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -24,9 +24,9 @@ class Modal extends React.Component {
     super(props);
     this.handleClose = this.handleClose.bind(this);
     this.handleDocumentKeyUp = this.handleDocumentKeyUp.bind(this);
-    this.state = { 
-      lastFocus: document.activeElement, 
-      focusListener: null 
+    this.state = {
+      lastFocus: document.activeElement,
+      focusListener: null
     };
   }
 


### PR DESCRIPTION
If the modal opens without a previous element ever having focus, there is a `TypeError` occurring in `componentWillReceiveProps`. This happens in the case of the DowntimeNotifications, which opens a modal upon page load if downtime is approaching. In that case, clicking the close button will result in an error and won't close the modal.

![image](https://user-images.githubusercontent.com/1915775/40240253-26f8d7b6-5a86-11e8-9938-d19c6e653464.png)
