### PR TITLE
Include Font Awesome animations module

### DIFF
--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -14,6 +14,7 @@
 @import "~font-awesome/scss/variables";
 @import "~font-awesome/scss/core";
 @import "~font-awesome/scss/icons";
+@import "~font-awesome/scss/animated";
 @font-face {
   font-family: "FontAwesome";
   src: url("~font-awesome/fonts/fontawesome-webfont.woff2") format("woff2"),


### PR DESCRIPTION
We sometimes use the class `fa-spin` thoughout `vets-website`. Unless there is a different method of animating a spinner we should be using instead, I think it makes sense to include this in the style build.

Resolves department-of-veterans-affairs/vets.gov-team/issues/11302