### PR TITLE
11398-breadcrumb-css

### DIFF
--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
@@ -25,13 +25,11 @@ class Breadcrumbs extends React.Component {
    */
   classNames() {
     const customClass = this.props.customClasses;
-    const mobileFirst = this.props.mobileFirstProp ? 'va-nav-breadcrumbs--mobile' : null;
+    const mobileFirst = this.props.mobileFirstProp
+      ? 'va-nav-breadcrumbs--mobile'
+      : null;
 
-    return classNames(
-      'va-nav-breadcrumbs',
-      mobileFirst,
-      customClass
-    );
+    return classNames('va-nav-breadcrumbs', mobileFirst, customClass);
   }
 
   /**
@@ -42,20 +40,23 @@ class Breadcrumbs extends React.Component {
     return React.Children.map(this.props.children, (child, i) => {
       if (i === this.props.children.length - 1) {
         return (
-          <li>{React.cloneElement(child, {
-            'aria-current': 'page',
-          })}</li>
+          <li>
+            {React.cloneElement(child, {
+              'aria-current': 'page'
+            })}
+          </li>
         );
       }
 
       return <li>{child}</li>;
     });
-  }
+  };
 
   render() {
     const { ariaLabel, mobileFirstProp } = this.props;
     const breadcrumbId = this.props.id || uniqueId('va-breadcrumbs-');
-    const breadcrumbListId = this.props.listId || uniqueId('va-breadcrumbs-list-');
+    const breadcrumbListId =
+      this.props.listId || uniqueId('va-breadcrumbs-list-');
 
     return (
       <nav
@@ -75,7 +76,7 @@ class Breadcrumbs extends React.Component {
 }
 
 Breadcrumbs.defaultProps = {
-  ariaLabel: 'Breadcrumb',
+  ariaLabel: 'Breadcrumb'
 };
 
 Breadcrumbs.propTypes = {
@@ -98,11 +99,11 @@ Breadcrumbs.propTypes = {
    */
   listId: PropTypes.string,
   /**
-   * Overrides the state object Boolean state.mobileShow.
-   * The mobile breadcrumb will always be rendered while
-   * mobileFirstProp is True.
+   * Adds CSS class `.va-nav-breadcrumbs--mobile` to the
+   * NAV element. The mobile breadcrumb will always
+   * be displayed while mobileFirstProp is True.
    */
-  mobileFirstProp: PropTypes.bool,
+  mobileFirstProp: PropTypes.bool
 };
 
 export default Breadcrumbs;

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
@@ -11,15 +11,6 @@ import { uniqueId } from 'lodash';
  * as props.children.
  */
 class Breadcrumbs extends React.Component {
-  // /** Experimenting with a speed boost that could be gleaned by only
-  //  * re-rendering when absolutely necessary
-  //  */
-  // shouldComponentUpdate(nextProps) {
-  //   const differentChildren = this.props.children !== nextProps.children;
-  //   const mobileWidth = this.props.mobileFirstProp !== nextProps.mobileFirstProp;
-  //   return differentChildren || mobileWidth;
-  // }
-
   /**
    * Provide a means to add overriding classes
    */

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { debounce, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * React component to dynamically build breadcrumb links.
@@ -11,52 +11,27 @@ import { debounce, uniqueId } from 'lodash';
  * as props.children.
  */
 class Breadcrumbs extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.breadcrumbId = this.props.id || uniqueId('va-breadcrumbs-');
-    this.breadcrumbListId = this.props.listId || uniqueId('va-breadcrumbs-list-');
-
-    this.state = {
-      mobileShow: false,
-    };
-  }
-
-  componentDidMount() {
-    const mobileWidth = this.props.mobileWidth;
-
-    this.toggleDisplay(mobileWidth);
-    window.addEventListener('resize', this.debouncedToggleDisplay);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.debouncedToggleDisplay);
-  }
-
-  debouncedToggleDisplay = debounce(() => {
-    const mobileWidth = this.props.mobileWidth;
-
-    this.toggleDisplay(mobileWidth);
-  }, 500);
+  // /** Experimenting with a speed boost that could be gleaned by only
+  //  * re-rendering when absolutely necessary
+  //  */
+  // shouldComponentUpdate(nextProps) {
+  //   const differentChildren = this.props.children !== nextProps.children;
+  //   const mobileWidth = this.props.mobileFirstProp !== nextProps.mobileFirstProp;
+  //   return differentChildren || mobileWidth;
+  // }
 
   /**
    * Provide a means to add overriding classes
    */
   classNames() {
     const customClass = this.props.customClasses;
+    const mobileFirst = this.props.mobileFirstProp ? 'va-nav-breadcrumbs--mobile' : null;
 
     return classNames(
       'va-nav-breadcrumbs',
+      mobileFirst,
       customClass
     );
-  }
-
-  /**
-   * Manage state to show all breadcrumb links or
-   * just the mobile "Back by one" link
-   */
-  toggleDisplay = breakpoint => {
-    this.setState({ mobileShow: window.innerWidth <= breakpoint });
   }
 
   /**
@@ -77,51 +52,23 @@ class Breadcrumbs extends React.Component {
     });
   }
 
-  /**
-   * The second to last link being sliced from the crumbs array
-   * prop to create the "Back by one" mobile breadcrumb link
-   */
-  renderMobileLink = () => {
-    return React.Children.map(this.props.children, (child, i) => {
-      if (i === this.props.children.length - 2) {
-        return (
-          <li>{React.cloneElement(child, {
-            'aria-label': `Previous page: ${child.props.children}`,
-            className: 'va-nav-breadcrumbs-list__mobile-link',
-          })}</li>
-        );
-      }
-
-      return null;
-    });
-  }
-
   render() {
-    const mobileShow = this.props.mobileFirstProp || this.state.mobileShow;
-    const shownList = mobileShow
-      ? (
-        <ul
-          className="row va-nav-breadcrumbs-list columns"
-          id={`${this.breadcrumbListId}-clone`}>
-          {this.renderMobileLink()}
-        </ul>
-      ) : (
-        <ul
-          className="row va-nav-breadcrumbs-list columns"
-          id={this.breadcrumbListId}>
-          {this.renderBreadcrumbLinks()}
-        </ul>
-      );
+    const { ariaLabel, mobileFirstProp } = this.props;
+    const breadcrumbId = this.props.id || uniqueId('va-breadcrumbs-');
+    const breadcrumbListId = this.props.listId || uniqueId('va-breadcrumbs-list-');
 
     return (
       <nav
-        aria-label={this.props.ariaLabel}
+        aria-label={ariaLabel}
         aria-live="polite"
         className={this.classNames()}
-        data-mobile-first={this.props.mobileFirstProp}
-        data-mobile-width={this.props.mobileWidth}
-        id={this.breadcrumbId}>
-        { shownList }
+        data-mobile-first={mobileFirstProp}
+        id={breadcrumbId}>
+        <ul
+          className="row va-nav-breadcrumbs-list columns"
+          id={breadcrumbListId}>
+          {this.renderBreadcrumbLinks()}
+        </ul>
       </nav>
     );
   }
@@ -129,7 +76,6 @@ class Breadcrumbs extends React.Component {
 
 Breadcrumbs.defaultProps = {
   ariaLabel: 'Breadcrumb',
-  mobileWidth: 481,
 };
 
 Breadcrumbs.propTypes = {
@@ -157,11 +103,6 @@ Breadcrumbs.propTypes = {
    * mobileFirstProp is True.
    */
   mobileFirstProp: PropTypes.bool,
-  /**
-   * Changes viewport width to update state.mobileShow
-   * and toggle breadcrumb UI change
-   */
-  mobileWidth: PropTypes.number.isRequired,
 };
 
 export default Breadcrumbs;

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.njk
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.njk
@@ -3,9 +3,9 @@ import Breadcrumbs from './Breadcrumbs';
 
 export default function BreadcrumbsExample(props) {
   const crumbs = [
-    <a href="#" key="1">Link 1</a>,
-    <a href="#" key="2">Link 2</a>,
-    <a href="#" key="3">Link 3</a>
+    <a href="#" key="1">Home</a>,
+    <a href="#" key="2">Level One</a>,
+    <a href="#" key="3">Level Two</a>
   ];
 
   return (

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.unit.spec.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.unit.spec.jsx
@@ -44,8 +44,7 @@ describe('<Breadcrumbs>', () => {
       <Breadcrumbs
         customClasses="foo test"
         id="foo"
-        listId="foo-list"
-        mobileWidth={375}>
+        listId="foo-list">
         {crumbs}
       </Breadcrumbs>
     );
@@ -56,7 +55,6 @@ describe('<Breadcrumbs>', () => {
     expect(navElem.props().className).to.include('va-nav-breadcrumbs');
     expect(navElem.props().className).to.include('foo test');
     expect(navElem.props().id).to.equal('foo');
-    expect(navElem.props()['data-mobile-width']).to.equal(375);
     expect(listElem.props().id).to.equal('foo-list');
   });
 
@@ -196,48 +194,16 @@ describe('<Breadcrumbs>', () => {
     expect(linkElem.length).to.equal(3);
   });
 
-  it('should render mobile breadcrumb when state is updated', () => {
+  it('should add mobile-only class when mobileFirstProp is true', () => {
     const tree = shallow(
-      <Breadcrumbs>
+      <Breadcrumbs mobileFirstProp>
         {crumbs}
       </Breadcrumbs>
     );
 
-    const linkElem = tree.find('a');
+    const navElem = tree.find('nav');
 
-    expect(linkElem.at(0).props()['aria-current']).to.be.undefined;
-    expect(linkElem.at(1).props()['aria-current']).to.be.undefined;
-    expect(linkElem.at(2).props()['aria-current']).to.equal('page');
-
-    tree.setState({ mobileShow: true });
-
-    const linkElemMobile = tree.find('a');
-
-    expect(linkElemMobile.length).to.equal(1);
-    expect(linkElemMobile.at(0).props()['aria-current']).to.be.undefined;
-    expect(linkElemMobile.props().className).to.equal('va-nav-breadcrumbs-list__mobile-link');
-  });
-
-  it('should render mobile breadcrumb when mobileFirstProp is true', () => {
-    const tree = shallow(
-      <Breadcrumbs>
-        {crumbs}
-      </Breadcrumbs>
-    );
-
-    const linkElem = tree.find('a');
-
-    expect(linkElem.at(0).props()['aria-current']).to.be.undefined;
-    expect(linkElem.at(1).props()['aria-current']).to.be.undefined;
-    expect(linkElem.at(2).props()['aria-current']).to.equal('page');
-
-    tree.setProps({ mobileFirstProp: true });
-
-    const linkElemMobile = tree.find('a');
-
-    expect(linkElemMobile.length).to.equal(1);
-    expect(linkElemMobile.at(0).props()['aria-current']).to.be.undefined;
-    expect(linkElemMobile.props().className).to.equal('va-nav-breadcrumbs-list__mobile-link');
+    expect(navElem.props().className).to.equal('va-nav-breadcrumbs va-nav-breadcrumbs--mobile');
   });
 
   it('should pass aXe check when showing full breadcrumb', () => {

--- a/src/components/navigation/Breadcrumbs/Breadcrumbs.unit.spec.jsx
+++ b/src/components/navigation/Breadcrumbs/Breadcrumbs.unit.spec.jsx
@@ -18,16 +18,6 @@ const routerCrumbs = [
   <Link to="/test2" key="3">Link 3</Link>,
 ];
 
-const test = shallow(
-  <Breadcrumbs>
-    <a href="/" key="1">Link 1</a>
-    <a href="/test1" key="2">Link 2</a>
-    <a href="/test2" key="3">Link 3</a>
-  </Breadcrumbs>
-);
-
-test.setState({ mobileShow: true });
-
 describe('<Breadcrumbs>', () => {
   it('should render', () => {
     const tree = shallow(
@@ -42,6 +32,7 @@ describe('<Breadcrumbs>', () => {
   it('should render custom props', () => {
     const tree = shallow(
       <Breadcrumbs
+        ariaLabel="Breadcrumb foo"
         customClasses="foo test"
         id="foo"
         listId="foo-list">
@@ -52,6 +43,7 @@ describe('<Breadcrumbs>', () => {
     const navElem = tree.find('nav');
     const listElem = tree.find('ul');
 
+    expect(navElem.props()['aria-label']).to.equal('Breadcrumb foo');
     expect(navElem.props().className).to.include('va-nav-breadcrumbs');
     expect(navElem.props().className).to.include('foo test');
     expect(navElem.props().id).to.equal('foo');
@@ -161,7 +153,7 @@ describe('<Breadcrumbs>', () => {
   it('should render individual children correctly', () => {
     const tree = shallow(
       <Breadcrumbs>
-        <a href="/" key="1">Link 1</a>
+        <a href="/" onClick={() => { const result = {}; return result; }} key="1">Link 1</a>
         <a href="/test1" key="2">Link 2</a>
         <a href="/test2" key="3">Link 3</a>
       </Breadcrumbs>

--- a/src/components/navigation/Breadcrumbs/README.md
+++ b/src/components/navigation/Breadcrumbs/README.md
@@ -37,13 +37,7 @@ Passing prop `listId="<STRING>"` to the `<Breadcrumbs />` component will append 
 
 ### mobileFirst (BOOLEAN)
 
-Passing prop `mobileFirstProp` to the `<Breadcrumbs />` component will override `state.mobileShow` and present the back by one mobile breadcrumb link on initial render or subsequent renders. This prop could be used in cases where developers want absolute control over which breadcrumb UI to show, instead of letting the user's viewport width toggle the correct view.
-
-### mobileWidth (NUMBER)
-
-Passing prop `mobileWidth={NUMBER}` to the `<Breadcrumbs />` component will modify the breakpoint width for swapping the full breadcrumb with the mobile "back by one" breadcrumb link. For instance, passing `mobileWidth="375"` to the Breadcrumb will trigger the mobile breadcrumb when a user resizes their window width to 375px or less.
-
-Zooming will also trigger the mobile breadcrumb. If a user zooms their window to 400% at 1200px wide, the mobile breadcrumb would be triggered, because 1200/4 = 300px.
+Passing prop `mobileFirstProp` to the `<Breadcrumbs />` component will add a class `va-nav-breadcrumbs--mobile` to the `<nav>` element, and hide all breadcrumb links except the previous step. This prop could be used in cases where developers want absolute control over which breadcrumb UI to show, instead of letting the user's viewport width toggle the correct view.
 
 ## Accessibility
 

--- a/src/sass/modules/_m-breadcrumbs.scss
+++ b/src/sass/modules/_m-breadcrumbs.scss
@@ -60,10 +60,46 @@
   position: relative;
 }
 
-.va-nav-breadcrumbs-list__mobile-link {
-  &::before {
-    content: " \2039 ";
+.va-nav-breadcrumbs--mobile {
+  li {
+    display: none;
+  }
+
+  li:nth-last-child(2) {
     display: inline-block;
-    padding: 0 0.15em;
+
+    &::before {
+      content: " \2039 ";
+      display: inline-block;
+      padding: 0 0.15em;
+    }
+
+    &::after {
+      content: "";
+      display: none;
+      padding: 0;
+    }
+  }
+}
+
+@media screen and (max-width: 481px) {
+  .va-nav-breadcrumbs li {
+    display: none;
+  }
+
+  .va-nav-breadcrumbs li:nth-last-child(2) {
+    display: inline-block;
+
+    &::before {
+      content: " \2039 ";
+      display: inline-block;
+      padding: 0 0.15em;
+    }
+
+    &::after {
+      content: "";
+      display: none;
+      padding: 0;
+    }
   }
 }

--- a/src/sass/modules/_m-breadcrumbs.scss
+++ b/src/sass/modules/_m-breadcrumbs.scss
@@ -60,6 +60,7 @@
   position: relative;
 }
 
+/* Mobile class declaration for React apps, manual override */
 .va-nav-breadcrumbs--mobile {
   li {
     display: none;
@@ -82,7 +83,8 @@
   }
 }
 
-@media screen and (max-width: 481px) {
+/* Activate the mobile breadcrumb at $small-screen breakpoint */
+@media screen and (max-width: $small-screen) {
   .va-nav-breadcrumbs li {
     display: none;
   }


### PR DESCRIPTION
## Purpose of this PR

The `<Breadcrumb />` component was making too many assumptions about the shape of its children. By using Javascript to pluck out the child, inline click handlers (analytics, other inline functions) ran the risk of being picked up. This new PR simplifies the Breadcrumb's mobile/full display by making it a CSS decision only.

I will bump the version number MINOR as I consider this to be a non-breaking API change. Users have all of the functionality as before, except the `aria-label` that was previously applied to the mobile-first crumb. In local testing, this seemed to not be a major loss. Will keep an ear out for user feedback and add back as needed later.

## Removed

* A number of unnecessary lifecycle methods, local state
* `mobileWidth` prop - this is now determined by CSS media query only

## Added

* Logic for adding a `va-nav-breadcrumbs--mobile` CSS class for always rendering the mobile view
* CSS for handling the breadcrumb transition as a media query, or CSS class
* CSS uses the `:nth-last-child` selector to hide all breadcrumb links, show just the second-to-last: https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child
* An inline click handler in unit test, to ensure these do not interfere with rendered output

## Tested

* Verified in Chrome, Firefox, Safari on OSX
* Verified in IE11, Firefox, Chrome on Win7
* iPhone 8
* Galaxy 5, 6, 7, 8, 8+, 9, 9+ in Chrome and Firefox