### PR TITLE
Update Modal screen reader hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -70,9 +70,8 @@ Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">E
 
       <h3>Get help from Veterans Crisis Line</h3>
 
-      <button class="va-modal-close va-overlay-close" type="button">
+      <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal">
         <i class="fa fa-close va-overlay-close"></i>
-        <span class="usa-sr-only va-overlay-close">Close this modal</span>
       </button>
 
       <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/header/vcl/vcl.njk
+++ b/src/components/header/vcl/vcl.njk
@@ -3,9 +3,8 @@
 
     <h3>Get help from Veterans Crisis Line</h3>
 
-    <button class="va-modal-close va-overlay-close" type="button" onClick="showModal(this);">
+    <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal" onClick="showModal(this);">
       <i class="fa fa-close va-overlay-close"></i>
-      <span class="usa-sr-only va-overlay-close">Close this modal</span>
     </button>
 
     <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -100,9 +100,9 @@ class Modal extends React.Component {
       closeButton = (<button
         className="va-modal-close"
         type="button"
+        aria-label="Close this modal"
         onClick={this.handleClose}>
         <i className="fa fa-close"></i>
-        <span className="usa-sr-only">Close this modal</span>
       </button>);
     }
 

--- a/src/sass/modules/_m-overlay.scss
+++ b/src/sass/modules/_m-overlay.scss
@@ -7,21 +7,6 @@
 // See vets.gov-team#1047
 //=============================================================
 
-// TODO: Safe to delete this now? Nothing seems to actually have the
-// `.va-overlay-close--icon` class applied to it.
-.va-overlay-close {
-  &--icon {
-    display: inline;
-    margin: 0;
-    padding: 1rem;
-    width: auto;
-
-    &:hover {
-      background: transparent;
-    }
-  }
-}
-
 .va-overlay {
   background: $color-va-modal-bg;
   height: 100%;

--- a/src/sass/modules/_m-overlay.scss
+++ b/src/sass/modules/_m-overlay.scss
@@ -4,9 +4,11 @@
 //
 // When the differences between our modals are
 // squared-away, we can remove this chunk.
-// See vets.gov-team#1047 
+// See vets.gov-team#1047
 //=============================================================
 
+// TODO: Safe to delete this now? Nothing seems to actually have the
+// `.va-overlay-close--icon` class applied to it.
 .va-overlay-close {
   &--icon {
     display: inline;


### PR DESCRIPTION
Switch to using an `aria-label` directly on the button element.
This seems to be a more modern, standards-compliant way to add
screen reader hints and fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11698