### PR TITLE
Bc megamenu mobile fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -13,6 +13,11 @@ const defaultSection = (sections) => {
 };
 
 export default class MegaMenu extends React.Component {
+  constructor() {
+    super();
+    this.originalSize = window.innerWidth;
+  }
+
   componentDidMount() {
     if (window.innerWidth < 768) {
       this.props.toggleDisplayHidden(true);
@@ -75,10 +80,12 @@ export default class MegaMenu extends React.Component {
   }
 
   resetDefaultState() {
-    if (window.innerWidth > 768) {
-      this.props.toggleDisplayHidden(false);
-    } else {
-      this.props.toggleDisplayHidden(true);
+    if (this.originalSize !== window.innerWidth) {
+      if (window.innerWidth > 768) {
+        this.props.toggleDisplayHidden(false);
+      } else {
+        this.props.toggleDisplayHidden(true);
+      }
     }
 
     this.props.updateCurrentSection('');


### PR DESCRIPTION
This is a fix for the MegaMenu scrolling issue on Mobile. IOS uses the resize event when scrolling so it causes the menu to hide. We don't want this. This checks if the size of the screen ever changes and if it doesn't it won't hide. You can only test this on an IOS device or on a simulator. Testing on Chrome won't be valid.