### PR TITLE
Remove button focus style override

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.4.0
+Version 1.4.9
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/form/controls/ProgressButton/ProgressButton.jsx
+++ b/src/components/form/controls/ProgressButton/ProgressButton.jsx
@@ -17,7 +17,6 @@ class ProgressButton extends React.Component {
 
     return (
       <button
-        form="myform"
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
         className={`${this.props.buttonClass} ${this.props.disabled ? 'usa-button-disabled' : null}`}

--- a/src/components/form/controls/ProgressButton/ProgressButton.jsx
+++ b/src/components/form/controls/ProgressButton/ProgressButton.jsx
@@ -17,6 +17,7 @@ class ProgressButton extends React.Component {
 
     return (
       <button
+        form="myform"
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
         className={`${this.props.buttonClass} ${this.props.disabled ? 'usa-button-disabled' : null}`}

--- a/src/sass/modules/_m-form-process.scss
+++ b/src/sass/modules/_m-form-process.scss
@@ -78,9 +78,6 @@
     &:active {
       background-color: $color-primary-darkest;
     }
-    &:focus {
-      outline: initial;
-    }
   }
   button.usa-button-secondary {
     color: $color-primary;


### PR DESCRIPTION
These changes allow the button focus style to be applied to buttons on form review pages.

<img width="583" alt="screen shot 2018-09-04 at 1 52 33 pm" src="https://user-images.githubusercontent.com/16051172/45057203-df48ee00-b049-11e8-8c4a-14326203334c.png">
.