### PR TITLE
Add role="button" rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/base/focus.scss
+++ b/src/sass/base/focus.scss
@@ -11,7 +11,7 @@ select:focus {
   @include focus-gold-light-outline;
 }
 
-[role="button"], button:focus {
+[role="button"]:focus, button:focus {
   @include focus-gold-light-outline;
   position: relative;
   z-index: 3;

--- a/src/sass/base/focus.scss
+++ b/src/sass/base/focus.scss
@@ -11,7 +11,7 @@ select:focus {
   @include focus-gold-light-outline;
 }
 
-button:focus {
+[role="button"], button:focus {
   @include focus-gold-light-outline;
   position: relative;
   z-index: 3;


### PR DESCRIPTION
## Description

The gold focus ring wasn't being applied to the file uploader's button because it's not a _real_ button. It's a label masquerading as a button with a `[role="button"]`. This PR fixes that by applying the same style to anything that's acting like a button with the role attribute.

I'm not sure what all is needed before we can use this in vets-website, but I think I might need to build? `npm run pre-publish`? Does that need to happen before we can merge this into master, or is that only needed before we can publish to npm?