### PR TITLE
Reverts changes from 1.5.1

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.5.1
+Version 1.5.2
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/CollapsiblePanel/CollapsiblePanel.jsx
+++ b/src/components/CollapsiblePanel/CollapsiblePanel.jsx
@@ -51,7 +51,6 @@ class CollapsiblePanel extends React.Component {
         <Element name={`collapsible-panel-${this.id}-scroll-element`}/>
         <div className="accordion-header clearfix">
           <button
-            type="button"
             className="usa-accordion-button usa-button-unstyled"
             aria-expanded={this.state.open ? 'true' : 'false'}
             aria-controls={`collapsible-${this.id}`}


### PR DESCRIPTION
- Reverts 1.5.1 due to unintended accordion button styling - adding a `type=button` is making the buttons blue.

This isn't handled as a straight revert because 1.5.1 fixed up some small issues with the package.json file.

Since the `usa-accordion-button` styling is straight from uswds, we'll need to figure out how to best change this.

