### PR TITLE
Accordion styling mg

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.6.0
+Version 1.6.1
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/CollapsiblePanel/CollapsiblePanel.jsx
+++ b/src/components/CollapsiblePanel/CollapsiblePanel.jsx
@@ -26,7 +26,11 @@ class CollapsiblePanel extends React.Component {
     });
   }
 
-  toggleChapter() {
+  toggleChapter(e) {
+    // USWDS styles make it difficult to add a type=button attribute to the toggle button.
+    // Until this changes, we need to ensure that accordions used in forms don't
+    // default to submitting a form page when toggled.
+    e.preventDefault();
     const isOpening = !this.state.open;
     this.setState((prevState) => ({ open: !prevState.open }), () => {
       if (isOpening) {

--- a/src/components/CollapsiblePanel/CollapsiblePanel.unit.spec.jsx
+++ b/src/components/CollapsiblePanel/CollapsiblePanel.unit.spec.jsx
@@ -16,6 +16,8 @@ describe('<CollapsiblePanel>', () => {
     };
   });
 
+  const event = { preventDefault: () => {} };
+
   it('should render the correct panel header', () => {
     const testHeaderText = 'Test panel';
     const wrapper = shallow(<CollapsiblePanel panelName={testHeaderText}/>);
@@ -29,10 +31,10 @@ describe('<CollapsiblePanel>', () => {
     const toggleButton = wrapper.find('button');
     expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
 
-    toggleButton.simulate('click');
+    toggleButton.simulate('click', event);
     expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
 
-    toggleButton.simulate('click');
+    toggleButton.simulate('click', event);
     expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
   });
 
@@ -42,10 +44,10 @@ describe('<CollapsiblePanel>', () => {
 
     expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
 
-    toggleButton.simulate('click');
+    toggleButton.simulate('click', event);
     expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
 
-    toggleButton.simulate('click');
+    toggleButton.simulate('click', event);
     expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
   });
 
@@ -56,7 +58,7 @@ describe('<CollapsiblePanel>', () => {
     const button = wrapper.find('button');
     expect(scrollSpy.called).to.be.false;
 
-    button.simulate('click');
+    button.simulate('click', event);
     expect(scrollSpy.calledOnce).to.be.true;
   });
 


### PR DESCRIPTION
## Description
Over-rides default `submit` behavior of accordion toggle buttons in the `<CollapsiblePanel>` component. This component was causing issues when used in forms because toggling a panel also submitted the form.

_Note:_ Ideally, this would be dealt with by adding a `type="button"` attribute to the toggle button. However, doing this causes a css rule for this type of button to turn the accordion button blue with black text. This is difficult to overcome because the root styles come from USWDS, so this change needs to be made by them. In the meantime, we'll just over-ride the button behavior.

## Testing
- Tested on local formation
- Tested locally in vets-website via [these](https://github.com/department-of-veterans-affairs/design-system/blob/master/previewing-changes.md) instructions

## AC
CollapsiblePanels:
- Start expanded when told to do so, or start collapsed by default
- Continue to be light gray / dark gray on hover (i.e., no visual changes)
- Continue to toggle when clicked
- Do *not* submit a form when used on a form page
