### PR TITLE
Mega Menu - Add onClick handler to links for event-tracking

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.7.1
+Version 1.7.2
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/MegaMenu/Column.jsx
+++ b/src/components/navigation/MegaMenu/Column.jsx
@@ -11,7 +11,7 @@ const isPanelWhite = (panelWhite) => {
 };
 
 const Column = (props) => {
-  const { data, keyName, panelWhite } = props;
+  const { data, keyName, panelWhite, columnThreeLinkClicked, linkClicked } = props;
 
   if (keyName === 'columnThree') {
     return (
@@ -21,7 +21,7 @@ const Column = (props) => {
         <div className="mm-marketing-container">
           <img src={data.img.src} alt={data.img.alt}></img>
           <div className="mm-marketing-text">
-            <a className="mm-links" href={data.link.href} onClick={props.columnThreeLinkClicked.bind(null, link)} target={data.link.target || '_self'}>
+            <a className="mm-links" href={data.link.href} onClick={columnThreeLinkClicked.bind(null, data.link)} target={data.link.target || '_self'}>
               {data.link.text}
             </a>
             <p>{data.description}</p>
@@ -39,7 +39,7 @@ const Column = (props) => {
 
         { data.links.map((link, i) => (
           <li className="mm-link-container" key={`${link.href}-${i}`}>
-            <a className="mm-links" href={link.href} onClick={props.linkClicked.bind(null, link)} target={link.target || '_self'}>
+            <a className="mm-links" href={link.href} onClick={linkClicked.bind(null, link)} target={link.target || '_self'}>
               {link.text}
             </a>
           </li>

--- a/src/components/navigation/MegaMenu/Column.jsx
+++ b/src/components/navigation/MegaMenu/Column.jsx
@@ -21,7 +21,7 @@ const Column = (props) => {
         <div className="mm-marketing-container">
           <img src={data.img.src} alt={data.img.alt}></img>
           <div className="mm-marketing-text">
-            <a className="mm-links" href={data.link.href} target={data.link.target || '_self'}>
+            <a className="mm-links" href={data.link.href} onClick={this.props.columnThreeLinkClicked} target={data.link.target || '_self'}>
               {data.link.text}
             </a>
             <p>{data.description}</p>
@@ -39,7 +39,7 @@ const Column = (props) => {
 
         { data.links.map((link, i) => (
           <li className="mm-link-container" key={`${link.href}-${i}`}>
-            <a className="mm-links" href={link.href} target={link.target || '_self'}>
+            <a className="mm-links" href={link.href} onClick={this.props.linkClicked} target={link.target || '_self'}>
               {link.text}
             </a>
           </li>
@@ -72,6 +72,8 @@ Column.propTypes = {
   keyName: PropTypes.string.isRequired,
   navTitle: PropTypes.string.isRequired,
   panelWhite: PropTypes.bool.isRequired,
+  linkClicked: PropTypes.func.isRequired,
+  columnThreeLinkClicked: PropTypes.func.isRequired
 };
 
 export default Column;

--- a/src/components/navigation/MegaMenu/Column.jsx
+++ b/src/components/navigation/MegaMenu/Column.jsx
@@ -21,7 +21,7 @@ const Column = (props) => {
         <div className="mm-marketing-container">
           <img src={data.img.src} alt={data.img.alt}></img>
           <div className="mm-marketing-text">
-            <a className="mm-links" href={data.link.href} onClick={this.props.columnThreeLinkClicked} target={data.link.target || '_self'}>
+            <a className="mm-links" href={data.link.href} onClick={props.columnThreeLinkClicked.bind(null, link)} target={data.link.target || '_self'}>
               {data.link.text}
             </a>
             <p>{data.description}</p>
@@ -39,7 +39,7 @@ const Column = (props) => {
 
         { data.links.map((link, i) => (
           <li className="mm-link-container" key={`${link.href}-${i}`}>
-            <a className="mm-links" href={link.href} onClick={this.props.linkClicked} target={link.target || '_self'}>
+            <a className="mm-links" href={link.href} onClick={props.linkClicked.bind(null, link)} target={link.target || '_self'}>
               {link.text}
             </a>
           </li>

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -149,7 +149,7 @@ export default class MegaMenu extends React.Component {
                           aria-haspopup="true"
                           className="vetnav-level1"
                           onClick={() => this.toggleDropDown(item.title)}>{item.title}</button>
-                          : <a href={item.href} onClick={linkClicked} className="vetnav-level1" target={item.target || null}>{item.title}</a>
+                          : <a href={item.href} onClick={linkClicked.bind(null, item)} className="vetnav-level1" target={item.target || null}>{item.title}</a>
                       }
                       <div id={`vetnav-${_.kebabCase(item.title)}`} className="vetnav-panel" role="none" hidden={currentDropdown !== item.title}>
                         {

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -124,6 +124,8 @@ export default class MegaMenu extends React.Component {
       currentSection,
       data,
       display,
+      linkClicked,
+      columnThreeLinkClicked
     } = this.props;
 
     return (
@@ -147,7 +149,7 @@ export default class MegaMenu extends React.Component {
                           aria-haspopup="true"
                           className="vetnav-level1"
                           onClick={() => this.toggleDropDown(item.title)}>{item.title}</button>
-                          : <a href={item.href} className="vetnav-level1" target={item.target || null}>{item.title}</a>
+                          : <a href={item.href} onClick={linkClicked} className="vetnav-level1" target={item.target || null}>{item.title}</a>
                       }
                       <div id={`vetnav-${_.kebabCase(item.title)}`} className="vetnav-panel" role="none" hidden={currentDropdown !== item.title}>
                         {
@@ -161,7 +163,9 @@ export default class MegaMenu extends React.Component {
                                     defaultSection={defaultSection(item.menuSections)}
                                     currentSection={currentSection}
                                     updateCurrentSection={() => this.updateCurrentSection(section.title)}
-                                    links={section.links}></MenuSection>
+                                    links={section.links}
+                                    linkClicked={linkClicked}
+                                    columnThreeLinkClicked={columnThreeLinkClicked}/>
                                 );
                               }) : this.getSubmenu(item,  currentSection)
                             }
@@ -215,6 +219,17 @@ MegaMenu.propTypes = {
    * String value of current dropdown section
    */
   currentSection: PropTypes.string,
+
+  /**
+   * Optional function to intercept links clicked
+   */
+  linkClicked: PropTypes.func,
+
+  /**
+   * Optional function to intercept links clicked at column three
+   */
+  columnThreeLinkClicked: PropTypes.func,
+
   display: PropTypes.shape({
     hidden: PropTypes.boolean
   }),
@@ -224,4 +239,6 @@ MegaMenu.defaultProps = {
   currentDropdown: '',
   currentSection: '',
   display: {},
+  linkClicked() {},
+  columnThreeLinkClicked() {}
 };

--- a/src/components/navigation/MegaMenu/MenuSection.jsx
+++ b/src/components/navigation/MegaMenu/MenuSection.jsx
@@ -60,7 +60,9 @@ class MenuSection extends React.Component {
           data={this.props.links}
           navTitle={this.props.title}
           show={show}
-          handleBackToMenu={() => this.handleBackToMenu()}>
+          handleBackToMenu={() => this.handleBackToMenu()}
+          linkClicked={this.props.linkClicked}
+          columnThreeLinkClicked={this.props.columnThreeLinkClicked}>
         </SubMenu>
       </li>
     );
@@ -106,6 +108,8 @@ MenuSection.propTypes = {
     }),
   }).isRequired,
   defaultSection: PropTypes.string.isRequired,
+  linkClicked: PropTypes.func.isRequired,
+  columnThreeLinkClicked: PropTypes.func.isRequired
 };
 
 export default MenuSection;

--- a/src/components/navigation/MegaMenu/SubMenu.jsx
+++ b/src/components/navigation/MegaMenu/SubMenu.jsx
@@ -46,7 +46,7 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu }) => {
 
         {
           seeAllLink && <div className="panel-bottom-link">
-            <a href={seeAllLink.href}>
+            <a href={seeAllLink.href} onClick={this.props.linkClicked}>
               View All in {seeAllLink.text}
               <img src="/img/arrow-right-blue.svg" alt="right-arrow"></img>
             </a>
@@ -60,7 +60,9 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu }) => {
               data={filteredColumns[keyName]}
               keyName={keyName}
               navTitle={navTitle}
-              panelWhite={Object.prototype.hasOwnProperty.call(filteredColumns, 'mainColumn')}>
+              panelWhite={Object.prototype.hasOwnProperty.call(filteredColumns, 'mainColumn')}
+              linkClicked={this.props.linkClicked}
+              columnThreeLinkClicked={this.props.columnThreeLinkClicked}>
             </Column>
           );
         })}
@@ -77,6 +79,8 @@ SubMenu.propTypes = {
   data: PropTypes.object.isRequired,
   show: PropTypes.bool.isRequired,
   navTitle: PropTypes.string.isRequired,
+  linkClicked: PropTypes.func.isRequired,
+  columnThreeLinkClicked: PropTypes.func.isRequired
 };
 
 export default SubMenu;

--- a/src/components/navigation/MegaMenu/SubMenu.jsx
+++ b/src/components/navigation/MegaMenu/SubMenu.jsx
@@ -27,7 +27,7 @@ const getColumns = (columns) => {
   return columns;
 };
 
-const SubMenu = ({ data, show, navTitle, handleBackToMenu }) => {
+const SubMenu = ({ data, show, navTitle, handleBackToMenu, linkClicked, columnThreeLinkClicked }) => {
   const { seeAllLink, ...columns } = data;
 
   if (show) {
@@ -46,7 +46,7 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu }) => {
 
         {
           seeAllLink && <div className="panel-bottom-link">
-            <a href={seeAllLink.href} onClick={this.props.linkClicked}>
+            <a href={seeAllLink.href} onClick={linkClicked.bind(null, seeAllLink)}>
               View All in {seeAllLink.text}
               <img src="/img/arrow-right-blue.svg" alt="right-arrow"></img>
             </a>
@@ -61,8 +61,8 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu }) => {
               keyName={keyName}
               navTitle={navTitle}
               panelWhite={Object.prototype.hasOwnProperty.call(filteredColumns, 'mainColumn')}
-              linkClicked={this.props.linkClicked}
-              columnThreeLinkClicked={this.props.columnThreeLinkClicked}>
+              linkClicked={linkClicked}
+              columnThreeLinkClicked={columnThreeLinkClicked}>
             </Column>
           );
         })}


### PR DESCRIPTION
This pull request is related to the work being done in https://github.com/department-of-veterans-affairs/vets-website/pull/8598.

We need a method of tracking when links are clicked, and the best way of doing that is by adding the `onClick` events to the links so that we can capture the event before the page navigates.