### PR TITLE
Don't change button position on focus

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.7.3
+Version 1.7.6
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/base/focus.scss
+++ b/src/sass/base/focus.scss
@@ -13,7 +13,6 @@ select:focus {
 
 [role="button"]:focus, button:focus {
   @include focus-gold-light-outline;
-  position: relative;
   z-index: 3;
 }
 


### PR DESCRIPTION
We had a problem of bouncing the buttons around when clicked because the `position` changed.

![pattern error.gif](https://images.zenhubusercontent.com/59c026b0b0222d5de4782ec6/8e353a4f-64e8-4a8b-9e42-0e0607906285)

This PR stops the position from changing once clicked.

I don't know why it was in here in the first place, so if you know of why it was needed originally, please let me know!