### PR TITLE
External icon fix

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.7.7
+Version 1.7.8
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -211,8 +211,7 @@ table {
 // Adds external icon to all links that begin
 // with http (including https)
 // Using this selector makes it easier for the content team to write content
-[href^="http"],
-[rel="external"] {
+a[href^="http"]:not([href*="va.gov"], [href*="vets.gov"]):not(.no-external-icon) {
   @include exit-icon;
 }
 


### PR DESCRIPTION
Refactors the external icon selector to work with new BC site and only apply the external icon to links that are not in `va.gov` or `vets.gov` domain and that *do not* have the `no-external-icon` class