### PR TITLE
Mega menu iPad update and fixes

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.7.8
+Version 1.8.0
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.7.8",
+  "version": "1.8.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/MegaMenu/Column.jsx
+++ b/src/components/navigation/MegaMenu/Column.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 const isPanelWhite = (panelWhite) => {
-  if (window.innerWidth < 768) {
+  if (document.body.clientWidth < 768) {
     return '';
   }
 

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -98,10 +98,10 @@ export default class MegaMenu extends React.Component {
       } else {
         this.props.toggleDisplayHidden(true);
       }
+      this.props.updateCurrentSection('');
+      this.props.toggleDropDown('');
+      this.originalSize = document.body.clientWidth;
     }
-
-    this.props.updateCurrentSection('');
-    this.props.toggleDropDown('');
   }
 
   toggleDropDown(title) {

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -5,7 +5,7 @@ import SubMenu from './SubMenu';
 import _ from 'lodash';
 
 const defaultSection = (sections) => {
-  if (window.innerWidth < 768) {
+  if (document.body.clientWidth < 768) {
     return '';
   }
 
@@ -15,11 +15,11 @@ const defaultSection = (sections) => {
 export default class MegaMenu extends React.Component {
   constructor() {
     super();
-    this.originalSize = window.innerWidth;
+    this.originalSize = document.body.clientWidth;
   }
 
   componentDidMount() {
-    if (window.innerWidth < 768) {
+    if (document.body.clientWidth < 768) {
       this.props.toggleDisplayHidden(true);
     }
 
@@ -36,7 +36,7 @@ export default class MegaMenu extends React.Component {
   }
 
   getSubmenu(item, currentSection) {
-    if (window.innerWidth < 768) {
+    if (document.body.clientWidth < 768) {
       const menuSections = [
         item.menuSections.mainColumn,
         item.menuSections.columnOne,
@@ -92,8 +92,8 @@ export default class MegaMenu extends React.Component {
   }
 
   resetDefaultState() {
-    if (this.originalSize !== window.innerWidth) {
-      if (window.innerWidth > 768) {
+    if (this.originalSize !== document.body.clientWidth) {
+      if (document.body.clientWidth > 768) {
         this.props.toggleDisplayHidden(false);
       } else {
         this.props.toggleDisplayHidden(true);
@@ -115,7 +115,7 @@ export default class MegaMenu extends React.Component {
   updateCurrentSection(title) {
     let sectionTitle = title;
 
-    if (window.innerWidth < 768) {
+    if (document.body.clientWidth < 768) {
       sectionTitle = this.props.currentSection === title ? '' : title;
     }
 

--- a/src/components/navigation/MegaMenu/MegaMenu.njk
+++ b/src/components/navigation/MegaMenu/MegaMenu.njk
@@ -220,7 +220,7 @@ export default class MegaMenuExample extends React.Component {
   }
 
   toggleDisplayHidden(hidden) {
-    if (window.innerWidth > 768) {
+    if (document.body.clientWidth > 768) {
       this.setState({
         display: {},
       });

--- a/src/components/navigation/MegaMenu/MenuSection.jsx
+++ b/src/components/navigation/MegaMenu/MenuSection.jsx
@@ -21,7 +21,7 @@ class MenuSection extends React.Component {
   }
 
   updateCurrentSection() {
-    if (window.innerWidth === 768) {
+    if (document.body.clientWidth < 768) {
       this.setState({
         title: {
           hidden: true,
@@ -35,7 +35,7 @@ class MenuSection extends React.Component {
   handleBackToMenu() {
     this.updateCurrentSection('');
 
-    if (window.innerWidth === 768) {
+    if (document.body.clientWidth < 768) {
       this.setState({
         title: {},
       });

--- a/src/components/navigation/MegaMenu/SubMenu.jsx
+++ b/src/components/navigation/MegaMenu/SubMenu.jsx
@@ -4,7 +4,7 @@ import Column from './Column';
 import _ from 'lodash';
 
 const onSmallScreen = () => {
-  if (window.innerWidth < 768) {
+  if (document.body.clientWidth < 768) {
     return true;
   }
 
@@ -12,7 +12,7 @@ const onSmallScreen = () => {
 };
 
 const getColumns = (columns) => {
-  if (window.innerWidth < 768) {
+  if (document.body.clientWidth < 768) {
     return {
       columnOne: {
         title: columns.columnOne.title,

--- a/src/sass/base/_b-breakpoints.scss
+++ b/src/sass/base/_b-breakpoints.scss
@@ -21,6 +21,7 @@ $large: new-breakpoint(min-width $large-screen $grid-columns-large);
 $xsmall-screen:       320px; // QVGA display
 $medium-large-screen: 768px;
 $medium-screen:       $medium-large-screen;
+$small-desktop-screen: 1008px;
 
 $medium: new-breakpoint(min-width $medium-large-screen 6);
 

--- a/src/sass/base/_b-mixins.scss
+++ b/src/sass/base/_b-mixins.scss
@@ -106,3 +106,47 @@
   background: linear-gradient(to bottom, $from 0%,$to 63%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=$from, endColorstr=$to,GradientType=0 ); /* IE6-9 */
 } 
+
+@mixin button-link {
+  background: none;
+  background-color: transparent !important;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  padding: 0 !important;
+  margin: 0;
+  text-align: left;
+  -webkit-font-smoothing: auto;
+  color: $color-link-default !important;
+  font-weight: normal;
+  text-decoration: underline;
+  display: inline;
+  width: auto !important;
+  line-height: inherit;
+  &:hover {
+    background: none;
+    border: 0;
+    border-radius: 0;
+    outline: 0;
+    padding: 0 !important;
+    color: $color-link-default;
+    text-decoration: underline;
+    background-color: $color-link-default-hover !important;
+    -webkit-transition-duration: 0.3s;
+    transition-duration: 0.3s;
+
+    -webkit-transition-timing-function: ease-in-out;
+    transition-timing-function: ease-in-out;
+
+    // Transition only these properties.
+    -webkit-transition-property: color, background-color, border-color;
+    transition-property: color, background-color, border-color;
+  }
+  &:active {
+    background: $color-link-default-hover;
+  }
+  &:focus {
+    @include focus-gold-light-outline;
+    outline-offset: 0;
+  }
+}

--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -18,47 +18,7 @@
 // look like a link. We have plenty of overspecified button styles, so there are
 // several instances in here of !important.
 .va-button-link {
-  background: none;
-  background-color: transparent !important;
-  border: 0;
-  border-radius: 0;
-  outline: 0;
-  padding: 0 !important;
-  margin: 0;
-  text-align: left;
-  -webkit-font-smoothing: auto;
-  color: $color-link-default !important;
-  font-weight: normal;
-  text-decoration: underline;
-  display: inline;
-  width: auto !important;
-  line-height: inherit;
-  &:hover {
-    background: none;
-    border: 0;
-    border-radius: 0;
-    outline: 0;
-    padding: 0 !important;
-    color: $color-link-default;
-    text-decoration: underline;
-    background-color: $color-link-default-hover !important;
-    -webkit-transition-duration: 0.3s;
-    transition-duration: 0.3s;
-
-    -webkit-transition-timing-function: ease-in-out;
-    transition-timing-function: ease-in-out;
-
-    // Transition only these properties.
-    -webkit-transition-property: color, background-color, border-color;
-    transition-property: color, background-color, border-color;
-  }
-  &:active {
-    background: $color-link-default-hover;
-  }
-  &:focus {
-    @include focus-gold-light-outline;
-    outline-offset: 0;
-  }
+  @include button-link;
 }
 
 .dashed-underline {

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -4,14 +4,82 @@
   width: 100%;
   z-index: 2;
 
+  .panel-bottom-link {
+    position: unset;
+    height: 25px;
+    margin-left: 10px;
+    margin-bottom: 3px;
+    border: none;
+
+    a {
+      padding: 20px 25px 20px 7px;
+      width: 111%;
+
+      img {
+        width: 15px;
+      }
+    }
+  }
+
+  .column-three {
+    display: none;
+  }
+
+  .vetnav-level2 {
+    width: 100%;
+  }
+
+  .panel-top-link {
+    &:nth-of-type(1) {
+      display: block;
+      font-weight: bold;
+      padding-top: 15px;
+    }
+  }
+
+  .vetnav-panel--submenu:not([hidden]) {
+    h3 {
+      display: none;
+    }
+  }
+
+  .back-button {
+    display: block;
+  }
+
+  .vetnav-panel {
+    height: auto;
+  }
+
+  .mm-link-container-small {
+    background: $color-primary-darkest;
+    height: 100%;
+    position: absolute;
+    width: 100%;
+    top: 0;
+    z-index: 200;
+  }
+
+  .all-link-arrow {
+    display: none;
+  }
+
+  .vetnav-level1 {
+    &:active, &:visited, &:focus, &:hover {
+      color: $color-white;
+    }
+  }
+
   @include media($medium-large-screen) {
     .vetnav-panel--submenu:not([hidden]) {
+      position: absolute;
       box-shadow: none;
       width: 26rem;
       padding: 72px 0px 0px 28px;
       white-space: normal;
 
       h3 {
+        display: initial;
         color: $color-black;
         font-family: Source Sans Pro, sans serif;
         font-size: 1.6rem;
@@ -27,6 +95,9 @@
 
     .vetnav-level1[aria-expanded="true"] {
       border-top-color: $color-va-accent;
+      &:active, &:visited, &:focus, &:hover {
+        color: $color-base;
+      }
     }
 
     .vetnav-level2[aria-expanded="true"] {
@@ -90,15 +161,27 @@
         padding: 14px 0px 0px 0px;
       }
     }
+
+    .panel-bottom-link {
+      margin: 0;
+    }
+
+    .all-link-arrow {
+      display: initial;
+    }
+
+    .panel-top-link {
+      display: none !important;
+    }
+
+    .vetnav-level2 {
+      width: 24.3rem;
+    }
   }
 
   .panel-title {
     font-weight: bold;
     color: $color-black;
-  }
-
-  .vetnav-level2 {
-    width: 24.3rem;
   }
 
   a.vetnav-level1 {
@@ -207,95 +290,51 @@
     }
   }
 
-  @media (max-width: 768px) {
+
+  @include media($medium-large-screen) {
+    .vetnav-panel {
+      width: $medium-large-screen;
+      height: 380px;
+    }
+
     .panel-bottom-link {
-      position: unset;
-      height: 25px;
-      margin-left: 10px;
-      margin-bottom: 3px;
-      border: none;
+      width: $medium-large-screen - 297px;
+    }
 
-      a {
-        padding: 20px 25px 20px 7px;
-        width: 111%;
+    .column-one {
+      width: 39rem;
+    }
 
-        img {
-          width: 15px;
-        }
-      }
+    .column-two {
+      width: 39rem;
     }
 
     .column-three {
       display: none;
     }
-
-    .vetnav-level2 {
-      width: 100%;
-    }
-
-    .panel-top-link {
-      &:nth-of-type(1) {
-        display: block;
-        font-weight: bold;
-        padding-top: 15px;
-      }
-    }
-
-    .vetnav-panel--submenu:not([hidden]) {
-      position: initial;
-
-      h3 {
-        display: none;
-      }
-    }
-
-    .back-button {
-      display: block;
-    }
-
-    .vetnav-panel {
-      height: auto;
-    }
-
-    .mm-link-container-small {
-      background: $color-primary-darkest;
-      height: 100%;
-      position: absolute;
-      width: 100%;
-      top: 0;
-      z-index: 200;
-    }
-
-    .all-link-arrow {
-      display: none;
-    }
   }
 
-  // IPad: fix for weirdness at 768 breakpoint on IPad
-  @media (min-width:768px) and (max-width:769px) {
-    .panel-bottom-link {
-      position: absolute;
-    }
-
-    .vetnav-panel--submenu:not([hidden]) {
-      position: absolute;
-      padding: 35px 0px 0px 28px;
-    }
-
+  @include media($small-desktop-screen) {
     .vetnav-panel {
-      height: 380px;
-    }
-
-    .mm-link-container {
-      width: 210px;
-
-      &[role="menuitem"] {
-        width: 243px;
-      }
+      width: $small-desktop-screen;
+      height: 460px;
     }
 
     .panel-bottom-link {
-      left: 26rem;
+      position: absolute;
+      width: $small-desktop-screen - 297px;
+    }
+
+    .column-one {
+      width: 26rem;
+    }
+
+    .column-two {
+      width: 26rem;
+    }
+
+    .column-three {
+      display: block;
     }
   }
 }


### PR DESCRIPTION
## Description

This fixes the various iPad issues listed in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13897 and also updates the menu to hide the promo section for widths from tablet to 1008px, which I've added as a new breakpoint based on a request from design.

## Testing
Browserstack and my own iPad

## Acceptance criteria
- [ ] Menus work on iPad correctly
- [ ] Promo spot is removed and not visible off screen