### PR TITLE
Use box-shadow inset on current-page indicator

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.8.1
+Version 1.8.2
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -268,8 +268,7 @@
 
   @include media($medium-large-screen) {
     .current-page {
-      border-bottom: 5px solid;
-      border-color: $color-blue;
+      box-shadow: inset 0 -5px 0 $color-blue;
       margin-left: 1.6rem;
       margin-right: 1.6rem;
       a {


### PR DESCRIPTION
## Description
Header has an extra 5px space that is not supposed to be there. This PR adds a class to override the formation `.current-page` class and reset the border, in favor of a `box-shadow: inset`

## Testing done
Visual acceptance tests in Chrome browser on Linux environment in responsive browser mode sizes 769px and up.

## Screenshots
Here is a screenshot of how it currently looks:
![Screen Shot 2018-09-28 at 1.43.26 PM.png](https://images.zenhubusercontent.com/5b0577164b5806bc2bd4524c/b0b1348c-8845-4d08-9890-996ada5d9a50)

Here is how this PR makes it look: 
![screenshot-localhost-3001-2018 10 18-06-04-11](https://user-images.githubusercontent.com/11085141/47150246-a8e2cd80-d29b-11e8-8ec5-7e824fd3e182.png)

## Acceptance criteria
- [X] Looks as though described in [originating issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13772)
