### PR TITLE
Fix gov banner styling

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -762,12 +762,18 @@ li {
   @include media($medium-large-screen) {
     background: $color-gray-lightest;
     .usa-banner-inner {
-      padding-left: 0;
+      padding-left: 1.5rem;
     }
 
     .usa-banner-content {
       padding-left: 0;
       padding-right: 0;
+    }
+  }
+
+  @include media($small-desktop-screen) {
+    .usa-banner-inner {
+      padding-left: 0rem;
     }
   }
 


### PR DESCRIPTION
This fixes the wrapping of the banner button on both WBC and vets.gov:

![screen shot 2018-10-19 at 2 38 18 pm](https://user-images.githubusercontent.com/634932/47237362-cbb0d700-d3ac-11e8-96c1-cadb7b788f6d.png)
![screen shot 2018-10-19 at 2 35 13 pm](https://user-images.githubusercontent.com/634932/47237363-cbb0d700-d3ac-11e8-99bb-f1c50e6375b0.png)
