### PR TITLE
Fix missing arrow styles

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.8.5
+Version 1.8.6
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/MegaMenu/arrow-right-blue.jsx
+++ b/src/components/navigation/MegaMenu/arrow-right-blue.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 export const ArrowRightBlueSVG = () => (
   <svg
+    className="all-link-arrow"
     width="444.819"
     height="444.819"
     viewBox="0 0 444.819 444.819">

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -16,7 +16,7 @@
       font-weight: bold;
       width: 111%;
 
-      img {
+      svg {
         width: 15px;
       }
     }


### PR DESCRIPTION
We missed some arrow styles when converting this to an SVG.

This puts it back to:

![screen shot 2018-10-25 at 12 12 14 pm](https://user-images.githubusercontent.com/634932/47514833-4f584100-d84f-11e8-8f3c-00d40e976b4b.png)
