### PR TITLE
Fixed no background image alerts

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.10.0
+Version 1.10.1
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/alerts/AlertBox/AlertBox.jsx
+++ b/src/components/alerts/AlertBox/AlertBox.jsx
@@ -63,7 +63,6 @@ class AlertBox extends React.Component {
           {alertText && <div className="usa-alert-text">{alertText}</div>}
         </div>
         {closeButton}
-        <div className="cf"></div>
       </div>
     );
   }

--- a/src/components/alerts/AlertBox/AlertBox.njk
+++ b/src/components/alerts/AlertBox/AlertBox.njk
@@ -37,7 +37,7 @@ export default function AlertBoxExample(props) {
         status={props.status}
         isVisible={false}/>
       <AlertBox
-        content={<p className="usa-alert-text">Content without heading.</p>}
+        content={<p>Content without heading.</p>}
         status={props.status}/>
     </div>
   );

--- a/src/components/alerts/StaticAlert/StaticAlert.njk
+++ b/src/components/alerts/StaticAlert/StaticAlert.njk
@@ -58,6 +58,13 @@
     </div>
   </div>
 
+  <div class="usa-alert usa-alert-info background-color-only">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">Information status - Background Color Only</h3>
+      <p>Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.</p>
+    </div>
+  </div>
+
   <script type="text/javascript">
 
     // Toggle the expandable crisis info

--- a/src/components/colors/colors.config.yml
+++ b/src/components/colors/colors.config.yml
@@ -49,7 +49,7 @@ context:
   - name: Primary Alt
     color:
     - var: color-primary-alt-lightest
-      name: "$color-primary-lightest"
+      name: "$color-primary-alt-lightest"
       hex: "#e1f3f8"
       contrast: AAA
     - var: color-primary-alt-light

--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -2,10 +2,6 @@
   width: 100%;
 }
 
-.no-background-image {
-  background-image: none;
-}
-
 .no-text-transform {
   text-transform: none;
 }

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -4,26 +4,22 @@
   border-left-style: solid;
   border-left-width: 10px;
   display: table;
-  min-height: 74px;
-  padding: 2rem;
-  padding-left: 4rem;
+  padding: 2rem 2rem 2rem 1.5rem;
   width: 100%;
 
   &::before {
     background: none;
     font-family: "FontAwesome";
     font-size: 2rem;
-    height: auto;
-    left: 1rem;
-    text-align: center;
-    top: 2rem;
-    width: 4rem;
+    margin-right: 1.5rem;
+    position: static;
   }
 
   &-body {
     display: table-cell;
     padding-left: 0;
     padding-right: 0;
+    width: 100%;
     vertical-align: middle;
   }
 
@@ -38,7 +34,6 @@
 
     &:only-child {
       margin: 0;
-      margin-top: 0.2rem;
       padding: 0;
     }
 

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -57,39 +57,69 @@
 
   &-info {
     border-left-color: $color-primary-alt-dark;
+
     &::before {
       content: "\f05a";
+    }
+
+    &.background-color-only {
+      background-color: $color-primary-alt-lightest;
     }
   }
 
   &-error {
     border-left-color: $color-secondary-dark;
+
     &::before {
       color: $color-secondary-dark;
       content: "\f06a"
+    }
+
+    &.background-color-only {
+      background-color: $color-secondary-lightest;
     }
   }
 
   &-success {
     border-left-color: $color-green;
+
     &::before {
       color: $color-green;
       content: "\f00c";
+    }
+
+    &.background-color-only {
+      background-color: $color-green-lightest;
     }
   }
 
   &-warning {
     border-left-color: $color-gold;
+
     &::before {
       content: "\f071";
+    }
+
+    &.background-color-only {
+      background-color: $color-gold-lightest;
     }
   }
 
   &-continue {
     border-left-color: $color-green;
+
     &::before {
       color: $color-green;
       content: "\f023";
+    }
+  }
+
+  &.background-color-only {
+    border-left: none;
+    padding: 2rem;
+
+    &::before {
+      content: none;
     }
   }
 }


### PR DESCRIPTION
Follow-up to #193. Forgot to account for the "alerts" that had no icons or borders.

I've renamed the class from `no-background-image` to `background-color-only` for accuracy. It was only being used for `usa-alert` elements, so I think the impact should be isolated. I will be updating `vets-website` and `vagov-content` accordingly.

Since the absolute positioning of the icon on the default alerts didn't seem necessary, I made some changes to that as well along with minor spacing tweaks.

<img width="698" alt="screen shot 2018-10-29 at 9 50 57 pm" src="https://user-images.githubusercontent.com/1067024/47690524-c16cb500-dbc4-11e8-910c-1fa4fabe68b8.png">