### PR TITLE
Higher precedence rule for usa-alert-body.

### DIFF
--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -15,7 +15,8 @@
     position: static;
   }
 
-  &-body {
+  // &-body would not have had high enough precedence.
+  & .usa-alert-body {
     display: table-cell;
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
Really minor change to override a `padding-left: 5rem` rule from USWDS.