### PR TITLE
Bumped version to publish package

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.10.2
+Version 1.10.3
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously published package was published from the wrong directory (top level instead of `dist/formation`).