### PR TITLE
Use match media to test screen size

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.10.3
+Version 1.10.4
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/navigation/MegaMenu/Column.jsx
+++ b/src/components/navigation/MegaMenu/Column.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
+const mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+
 const isPanelWhite = (panelWhite) => {
-  if (document.body.clientWidth < 768) {
+  if (mobileMediaQuery.matches) {
     return '';
   }
 

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -20,7 +20,7 @@ export default class MegaMenu extends React.Component {
       this.props.toggleDisplayHidden(true);
     }
 
-    mobileMediaQuery.addListener(this.resetDefaultState.bind(this));
+    mobileMediaQuery.addListener(this.resetDefaultState);
     document.body.addEventListener('click', this.handleDocumentClick, false);
   }
 
@@ -28,7 +28,7 @@ export default class MegaMenu extends React.Component {
    * Remove event listener
    */
   componentWillUnmount() {
-    mobileMediaQuery.removeListener(this.resetDefaultState.bind(this));
+    mobileMediaQuery.removeListener(this.resetDefaultState);
     document.body.removeEventListener('click', this.handleDocumentClick, false);
   }
 
@@ -88,7 +88,7 @@ export default class MegaMenu extends React.Component {
 
   }
 
-  resetDefaultState() {
+  resetDefaultState = () => {
     if (mobileMediaQuery.matches) {
       this.props.toggleDisplayHidden(true);
     } else {

--- a/src/components/navigation/MegaMenu/MegaMenu.jsx
+++ b/src/components/navigation/MegaMenu/MegaMenu.jsx
@@ -4,8 +4,10 @@ import MenuSection from './MenuSection';
 import SubMenu from './SubMenu';
 import _ from 'lodash';
 
+const mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+
 const defaultSection = (sections) => {
-  if (document.body.clientWidth < 768) {
+  if (mobileMediaQuery.matches) {
     return '';
   }
 
@@ -13,17 +15,12 @@ const defaultSection = (sections) => {
 };
 
 export default class MegaMenu extends React.Component {
-  constructor() {
-    super();
-    this.originalSize = document.body.clientWidth;
-  }
-
   componentDidMount() {
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       this.props.toggleDisplayHidden(true);
     }
 
-    window.addEventListener('resize', this.resetDefaultState.bind(this));
+    mobileMediaQuery.addListener(this.resetDefaultState.bind(this));
     document.body.addEventListener('click', this.handleDocumentClick, false);
   }
 
@@ -31,12 +28,12 @@ export default class MegaMenu extends React.Component {
    * Remove event listener
    */
   componentWillUnmount() {
-    window.removeEventListener('resize', this.resetDefaultState.bind(this));
+    mobileMediaQuery.removeListener(this.resetDefaultState.bind(this));
     document.body.removeEventListener('click', this.handleDocumentClick, false);
   }
 
   getSubmenu(item, currentSection) {
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       const menuSections = [
         item.menuSections.mainColumn,
         item.menuSections.columnOne,
@@ -92,16 +89,13 @@ export default class MegaMenu extends React.Component {
   }
 
   resetDefaultState() {
-    if (this.originalSize !== document.body.clientWidth) {
-      if (document.body.clientWidth > 768) {
-        this.props.toggleDisplayHidden(false);
-      } else {
-        this.props.toggleDisplayHidden(true);
-      }
-      this.props.updateCurrentSection('');
-      this.props.toggleDropDown('');
-      this.originalSize = document.body.clientWidth;
+    if (mobileMediaQuery.matches) {
+      this.props.toggleDisplayHidden(true);
+    } else {
+      this.props.toggleDisplayHidden(false);
     }
+    this.props.updateCurrentSection('');
+    this.props.toggleDropDown('');
   }
 
   toggleDropDown(title) {
@@ -115,7 +109,7 @@ export default class MegaMenu extends React.Component {
   updateCurrentSection(title) {
     let sectionTitle = title;
 
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       sectionTitle = this.props.currentSection === title ? '' : title;
     }
 

--- a/src/components/navigation/MegaMenu/MenuSection.jsx
+++ b/src/components/navigation/MegaMenu/MenuSection.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import SubMenu from './SubMenu';
 import _ from 'lodash';
 
+const mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+
 class MenuSection extends React.Component {
   constructor() {
     super();
@@ -21,7 +23,7 @@ class MenuSection extends React.Component {
   }
 
   updateCurrentSection() {
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       this.setState({
         title: {
           hidden: true,
@@ -35,7 +37,7 @@ class MenuSection extends React.Component {
   handleBackToMenu() {
     this.updateCurrentSection('');
 
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       this.setState({
         title: {},
       });

--- a/src/components/navigation/MegaMenu/SubMenu.jsx
+++ b/src/components/navigation/MegaMenu/SubMenu.jsx
@@ -4,20 +4,11 @@ import Column from './Column';
 import _ from 'lodash';
 import { ArrowRightBlueSVG }  from './arrow-right-blue';
 
-const onSmallScreen = () => {
-  if (document.body.clientWidth < 768) {
-    return true;
-  }
-
-  return false;
-};
-
-const onSmallDesktopOrLargeTablet = () => {
-  return !onSmallScreen() && document.body.clientWidth < 1008;
-};
+const mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+const smallDesktopMediaQuery = window.matchMedia('(min-width: 768px and max-width: 1007px)');
 
 const getColumns = (columns) => {
-  if (onSmallScreen()) {
+  if (mobileMediaQuery.matches) {
     return {
       columnOne: {
         title: columns.columnOne.title,
@@ -39,7 +30,7 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu, linkClicked, columnTh
     const filteredColumns = getColumns(columns);
 
     return (
-      <div className={onSmallScreen() ? 'mm-link-container-small' : ''}>
+      <div className={mobileMediaQuery.matches ? 'mm-link-container-small' : ''}>
         <div>
           <button
             className="back-button"
@@ -67,7 +58,7 @@ const SubMenu = ({ data, show, navTitle, handleBackToMenu, linkClicked, columnTh
               navTitle={navTitle}
               panelWhite={Object.prototype.hasOwnProperty.call(filteredColumns, 'mainColumn')}
               linkClicked={linkClicked}
-              hidden={keyName === 'columnThree' && onSmallDesktopOrLargeTablet()}
+              hidden={keyName === 'columnThree' && smallDesktopMediaQuery.matches}
               columnThreeLinkClicked={columnThreeLinkClicked}>
             </Column>
           );


### PR DESCRIPTION
So it turns out that using `document.body.clientWidth` doesn't account for the scrollbar that may appear on desktop pages. I didn't think this was an issue, but it leaves a gap in our media queries vs our code, leading to the linked issue.

Since `window.innerWidth` is flaky on device emulators, I thought a better option generally would be to use `matchMedia`.

![screen shot 2018-10-31 at 2 24 38 pm](https://user-images.githubusercontent.com/634932/47810038-b9258e80-dd18-11e8-9737-56b0cd3d4793.png)
