### PR TITLE
Remove instances of exit-icon

### DIFF
--- a/src/components/navigation/navigation/navigation.njk
+++ b/src/components/navigation/navigation/navigation.njk
@@ -37,7 +37,7 @@
                   <li><a href="/disability-benefits/conditions/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Conditions</a></li>
                   <li><a class="login-required" href="/track-claims/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Check claim and appeal status</a></li>
                   <li><a href="/disability-benefits/claims-appeal/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Appeals process</a></li>
-                  <li><a class="usa-button va-button-primary va-external--light" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Go to eBenefits to apply {{ "assets/img/icons/exit-icon-white.svg" }}</a></li>
+                  <li><a class="usa-button va-button-primary va-external--light" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Go to eBenefits to apply</a></li>
                 </ul>
               </li>
 

--- a/src/sass/base/_b-mixins.scss
+++ b/src/sass/base/_b-mixins.scss
@@ -57,7 +57,6 @@
 @mixin exit-icon {
   // Using longhand properties instead of the shorthand to limit
   // risk and impact of side effects
-  background-image: url(/img/icons/exit-icon.png);
   background-position: 100% 50%;
   background-repeat: no-repeat;
   background-size: 1em auto;
@@ -105,7 +104,7 @@
   background: -webkit-linear-gradient(top, $from 0%,$to 63%); /* Chrome10-25,Safari5.1-6 */
   background: linear-gradient(to bottom, $from 0%,$to 63%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=$from, endColorstr=$to,GradientType=0 ); /* IE6-9 */
-} 
+}
 
 @mixin button-link {
   background: none;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -208,13 +208,6 @@ table {
   position: fixed;
 }
 
-// Adds external icon to all links that begin
-// with http (including https)
-// Using this selector makes it easier for the content team to write content
-a[href^="http"]:not([href*="va.gov"], [href*="vets.gov"]):not(.no-external-icon) {
-  @include exit-icon;
-}
-
 // Logo and Header
 .header {
   background: $color-primary-darkest;

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -40,26 +40,6 @@ button,
   background-color: inherit;
 }
 
-.usa-button-secondary-exit {
-  &::after {
-    background-image: url(/img/icons/exit-icon-primary.png);
-    background-size: 1em auto;
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    // Content must have a decender in it
-    content: "leave vets.gov";
-    background-repeat: no-repeat;
-    background-position: top center;
-    margin-left: .3em;
-    text-indent: -9999em;
-    padding-right: 1.1em;
-  }
-  &:hover::after {
-    background-image: url(/img/icons/exit-icon-primary-darker.png);
-  }
-}
-
 .usa-button-disabled {
   background-color: $color-gray-lighter;
 }

--- a/src/sass/modules/_m-hub-page-link-list.scss
+++ b/src/sass/modules/_m-hub-page-link-list.scss
@@ -32,11 +32,3 @@
     margin: 0;
   }
 }
-.external-link-icon-black {
-  background-image: url(/img/icons/exit-icon.png);
-  background-position: 100% 50%;
-  background-repeat: no-repeat;
-  background-size: 1em auto;
-  padding-right: 1.2em;
-  position: relative;
-}

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -164,14 +164,6 @@
       }
     }
   }
-
-  span.exit-icon {
-    background-image: url(/img/icons/exit-icon-primary.png);
-    background-position: 100% 50%;
-    background-repeat: no-repeat;
-    background-size: 1em auto;
-    padding-right: 1.2em;
-  }
 }
 
 .va-modal-body {

--- a/src/sass/modules/_m-nav-linkslist.scss
+++ b/src/sass/modules/_m-nav-linkslist.scss
@@ -37,17 +37,6 @@
       display: block;
       padding: 0;
       text-decoration: none;
-
-      &[href^=http],
-      &[rel=external] {
-        h1, h2, h3, h4, h5, span {
-          &:first-child{
-            @include exit-icon;
-
-            display: inline-block;
-          }
-        }
-      }
     }
 
     li {


### PR DESCRIPTION
## Background
Per product owner, remove the external link icon from any and all URLs across our va.gov.

## Testing
Visually verified that the exit-icon has been removed from external links

## Screenshots
![2018-11-05-104625_1064x536_scrot](https://user-images.githubusercontent.com/11085141/48012727-476a8d80-e0e8-11e8-9408-2419d19712cd.png)
