### PR TITLE
Add heading classes

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.11.0
+Version 1.12.0
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -40,3 +40,25 @@
 .js-hide {
   display: none !important;
 }
+
+.heading-level {
+  &-1 {
+    @include h1();
+  }
+  &-2 {
+    @include h2();
+  }
+  &-3 {
+    @include h3();
+  }
+  &-4 {
+    @include h4();
+  }
+  &-5 {
+    @include h5();
+  }
+  &-6 {
+    @include h6();
+    font-family: $font-sans;
+  }
+}


### PR DESCRIPTION
USWDS styles heading elements directly, so we often pick a heading level based on style, instead of the markup structure of the page. This ends up causing accessibility issues.

This PR adds some heading classes so that we can flexibly style `h` elements and choose the correct one for the page.