### PR TITLE
Additional information heading

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.12.0
+Version 1.12.1
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -23,6 +23,8 @@ export default class AdditionalInfo extends React.Component {
       'fa-angle-down': true,
       open: this.state.open
     });
+    const { tagName: TagName = 'span' } = this.props;
+
     const trigger = (
       <button
         type="button"
@@ -30,14 +32,10 @@ export default class AdditionalInfo extends React.Component {
         aria-expanded={this.state.open ? 'true' : 'false'}
         aria-controls={this.expandedContentId}
         onClick={this.toggle}>
-        {this.props.isHeading && <h4 className="additional-info-title">
+        <TagName className="additional-info-title">
           {triggerText}
           <i className={iconClass}/>
-        </h4>}
-        {!this.props.isHeading && <span className="additional-info-title">
-          {triggerText}
-          <i className={iconClass}/>
-        </span>}
+        </TagName>
       </button>
     );
 

--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -30,10 +30,14 @@ export default class AdditionalInfo extends React.Component {
         aria-expanded={this.state.open ? 'true' : 'false'}
         aria-controls={this.expandedContentId}
         onClick={this.toggle}>
-        <span className="additional-info-title">
+        {this.props.isHeading && <h4 className="additional-info-title">
           {triggerText}
           <i className={iconClass}/>
-        </span>
+        </h4>}
+        {!this.props.isHeading && <span className="additional-info-title">
+          {triggerText}
+          <i className={iconClass}/>
+        </span>}
       </button>
     );
 

--- a/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
@@ -18,9 +18,16 @@ describe('<AdditionalInfo/>', () => {
 
   it('should render', () => {
     expect(wrapper.text()).to.contain('test');
+    expect(wrapper.find('h4').length).to.equal(0);
   });
   it('should pass aXe check', () => {
     return axeCheck(<AdditionalInfo triggerText="test"/>);
+  });
+  it('should render title container as heading', () => {
+    wrapper = mount(<AdditionalInfo isHeading triggerText="test"/>).setState({
+      open: true
+    });
+    expect(wrapper.find('h4').length).to.equal(1);
   });
   it('renders both children when open is true', () => {
     const first = wrapper.find('ExpandingGroup').props();

--- a/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('<AdditionalInfo/>', () => {
     return axeCheck(<AdditionalInfo triggerText="test"/>);
   });
   it('should render title container as heading', () => {
-    wrapper = mount(<AdditionalInfo isHeading triggerText="test"/>).setState({
+    wrapper = mount(<AdditionalInfo tagName={'h4'} triggerText="test"/>).setState({
       open: true
     });
     expect(wrapper.find('h4').length).to.equal(1);


### PR DESCRIPTION
These changes update the additional information component to support setting the trigger text as an h4 element, using the `isHeading` prop.

![image](https://user-images.githubusercontent.com/16051172/49356597-eef3c500-f680-11e8-8ebf-482e85c08388.png)

![image](https://user-images.githubusercontent.com/16051172/49356592-ec916b00-f680-11e8-9d1d-2f782eb391c1.png)

