### PR TITLE
Apply focus to modals that are visible on mount

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.12.1
+Version 1.12.2
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -5,6 +5,13 @@ import classNames from 'classnames';
 const ESCAPE_KEY = 27;
 
 class Modal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      lastFocus: null,
+    }
+  }
+
   componentDidMount() {
     if (this.props.visible) {
       this.setupModal();
@@ -20,7 +27,9 @@ class Modal extends React.Component {
   }
 
   componentWillUnmount() {
-    this.teardownModal();
+    if (this.props.visible) {
+      this.teardownModal();
+    }
   }
 
   setupModal() {
@@ -34,7 +43,7 @@ class Modal extends React.Component {
   }
 
   teardownModal() {
-    this.state.lastFocus.focus();
+    this.state.lastFocus && this.state.lastFocus.focus();
     document.body.classList.remove('modal-open');
     document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
     document.removeEventListener('focus', this.handleDocumentFocus, true);

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -9,7 +9,7 @@ class Modal extends React.Component {
     super(props);
     this.state = {
       lastFocus: null,
-    }
+    };
   }
 
   componentDidMount() {
@@ -43,7 +43,9 @@ class Modal extends React.Component {
   }
 
   teardownModal() {
-    this.state.lastFocus && this.state.lastFocus.focus();
+    if (this.state.lastFocus) {
+      this.state.lastFocus.focus();
+    }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
     document.removeEventListener('focus', this.handleDocumentFocus, true);
@@ -117,7 +119,7 @@ class Modal extends React.Component {
     }
 
     return (
-      <div className={modalCss} id={id} role="alertdialog" aria-labelledby={`${id}-title`} ref={el => this.element = el}>
+      <div className={modalCss} id={id} role="alertdialog" aria-labelledby={`${id}-title`} ref={el => { this.element = el; }}>
         <div className="va-modal-inner">
           {modalTitle}
           {closeButton}

--- a/src/components/modal/Modal.unit.spec.jsx
+++ b/src/components/modal/Modal.unit.spec.jsx
@@ -10,6 +10,7 @@ describe('<Modal/>', () => {
   it('should render', () => {
     const tree = mount(<Modal id="modal" title="Modal title" visible onClose={() => {}}>Modal contents</Modal>);
     expect(tree.text()).to.contain('Modal contents');
+    tree.unmount();
   });
 
   it('should setup event listeners and tear them down', () => {

--- a/src/components/modal/Modal.unit.spec.jsx
+++ b/src/components/modal/Modal.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
 import { expect } from 'chai';
 import { axeCheck } from '../../../lib/testing/helpers';
 
@@ -7,8 +8,24 @@ import Modal from './Modal.jsx';
 
 describe('<Modal/>', () => {
   it('should render', () => {
-    const tree = shallow(<Modal id="modal" title="Modal title" visible onClose={() => {}}>Modal contents</Modal>);
+    const tree = mount(<Modal id="modal" title="Modal title" visible onClose={() => {}}>Modal contents</Modal>);
     expect(tree.text()).to.contain('Modal contents');
+  });
+
+  it('should setup event listeners and tear them down', () => {
+    sinon.spy(global.document, 'addEventListener');
+    sinon.spy(global.document, 'removeEventListener');
+
+    const totalListeners = 3;
+    const tree = mount(<Modal id="modal" title="Modal title" visible clickToClose onClose={() => {}}>Modal contents</Modal>);
+
+    expect(global.document.addEventListener.callCount).to.be.equal(totalListeners);
+
+    tree.unmount();
+    expect(global.document.removeEventListener.callCount).to.be.equal(totalListeners);
+
+    global.document.addEventListener.restore();
+    global.document.removeEventListener.restore();
   });
 
   it('should pass aXe check', () => {


### PR DESCRIPTION
Modals that have the `visible` property set to `true` upon mount aren't receiving keyboard focus, as is visible on the VA.gov Welcome Modal. In the looking at the source for the Modal, there was more setup process involved for the modal than just the keyboard focus, so I consolidated that setup process into a single function, `setupModal`, and the teardown process into `teardownModal`. Then, we could just add a call to `setupModal` in `componentDidMount` when `this.props.visible` is true.

Related ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14903

## Screenshots
This super grainy video refreshes the page, and shows the Welcome Modal open with focus. Then it's closed using the escape key.

![modal-focus](https://user-images.githubusercontent.com/1915775/49535620-9ac02f00-f892-11e8-86e2-e249f813f2d0.gif)

## Testing done
- Tested the Welcome Modal
- Tested the edit modals on `/profile`