### PR TITLE
Margin utility

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.12.2
+Version 1.13.0
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 
@@ -42,6 +42,10 @@ See [design system](https://department-of-veterans-affairs.github.io/design-syst
 - SystemDownView.js
 - Tooltip.js
 - MegaMenu.js
+
+## Included utilities:
+
+- Margins
 
 ## Styles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/base/_b-breakpoints.scss
+++ b/src/sass/base/_b-breakpoints.scss
@@ -25,6 +25,15 @@ $small-desktop-screen: 1008px;
 
 $medium: new-breakpoint(min-width $medium-large-screen 6);
 
+
+$breakpoints: (
+  xsmall-screen:        $xsmall-screen,
+  small-screen:         $small-screen,
+  medium-screen:        $medium-screen,
+  small-desktop-screen: $small-desktop-screen,
+  large-screen:         $large-screen
+);
+
 // This is an override on Neat's media mixin to create media queries for both screen and print
 // https://github.com/thoughtbot/neat/blob/v1.8.0/app/assets/stylesheets/grid/_media.scss
 @mixin media($query: $feature $value $columns, $total-columns: $grid-columns) {

--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -77,7 +77,7 @@ $color-old-browser-background-end: #112e51;
 
 //===================================
 // Hub Icon colors for BC
-// 
+//
 //===================================
 
 $red-70v: #8b1303;
@@ -112,3 +112,31 @@ $low-layer: 100;
 $middle-layer: 200;
 $top-layer: 300;
 $modal-layer: 400;
+
+
+//===================================
+// Spacing
+//===================================
+/*
+## Learn more
+- [The 8-Point Grid](https://spec.fm/specifics/8-pt-grid)
+*/
+$multiple: 8px !default;
+
+$spacers: (
+  0:    0,
+  1px:  1px,
+  0p25: $multiple / 4,
+  0p5:  $multiple / 2,
+  1:    $multiple,
+  1p5:  $multiple * 1.5,
+  2:    $multiple * 2,
+  2p5:  $multiple * 2.5,
+  3:    $multiple * 3,
+  4:    $multiple * 4,
+  5:    $multiple * 5,
+  6:    $multiple * 6,
+  7:    $multiple * 7,
+  8:    $multiple * 8,
+  9:    $multiple * 9
+) !default;

--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -63,3 +63,6 @@
 // ----- VA GENERAL (MAIN FILE/OTHER) ---- //
 @import "base/va";
 @import "base/focus";
+
+// ----- VA UTILITIES (UTILITIY OOCSS) ---- //
+@import "utilities/margins"

--- a/src/sass/utilities/_margins.scss
+++ b/src/sass/utilities/_margins.scss
@@ -1,0 +1,158 @@
+/*
+Margin
+
+Use the margin utility to change an element's margin.
+*/
+
+// Auto Margins
+.vads-u-margin-x--auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+.vads-u-margin-y--auto {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+
+.vads-u-margin-top--auto {
+  margin-top: auto !important;
+}
+
+.vads-u-margin-right--auto {
+  margin-right: auto !important;
+}
+
+.vads-u-margin-bottom--auto {
+  margin-bottom: auto !important;
+}
+
+.vads-u-margin-left--auto {
+  margin-left: auto !important;
+}
+
+// Responsive classes
+@each $name, $value in $spacers {
+  .vads-u-margin--#{$name} {
+    margin: $value !important;
+  }
+
+  // Positive Values
+  .vads-u-margin-x--#{$name} {
+    margin-left: $value !important;
+    margin-right: $value !important;
+  }
+
+  .vads-u-margin-y--#{$name} {
+    margin-top: $value !important;
+    margin-bottom: $value !important;
+  }
+
+  .vads-u-margin-top--#{$name} {
+    margin-top: $value !important;
+  }
+
+  .vads-u-margin-right--#{$name} {
+    margin-right: $value !important;
+  }
+
+  .vads-u-margin-bottom--#{$name} {
+    margin-bottom: $value !important;
+  }
+
+  .vads-u-margin-left--#{$name} {
+    margin-left: $value !important;
+  }
+
+  //Negative values
+  .vads-u-margin-x--neg#{$name} {
+    margin-left: -$value !important;
+    margin-right: -$value !important;
+  }
+
+  .vads-u-margin-y--neg#{$name} {
+    margin-top: -$value !important;
+    margin-bottom: -$value !important;
+  }
+
+  .vads-u-margin-top--neg#{$name} {
+    margin-top: -$value !important;
+  }
+
+  .vads-u-margin-right--neg#{$name} {
+    margin-right: -$value !important;
+  }
+
+  .vads-u-margin-bottom--neg#{$name} {
+    margin-bottom: -$value !important;
+  }
+
+  .vads-u-margin-left--neg#{$name} {
+    margin-left: -$value !important;
+  }
+}
+
+@each $bp_name, $bp_value in $breakpoints {
+
+  @media (min-width: $bp_value) {
+    @each $name, $value in $spacers {
+      .#{$bp_name}\:vads-u-margin--#{$name} {
+        margin: $value !important;
+      }
+
+      // Positive Values
+      .#{$bp_name}\:vads-u-margin-x--#{$name} {
+        margin-left: $value !important;
+        margin-right: $value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-y--#{$name} {
+        margin-top: $value !important;
+        margin-bottom: $value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-top--#{$name} {
+        margin-top: $value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-right--#{$name} {
+        margin-right: $value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-bottom--#{$name} {
+        margin-bottom: $value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-left--#{$name} {
+        margin-left: $value !important;
+      }
+
+      //Negative values
+      .#{$bp_name}\:vads-u-margin-x--neg#{$name} {
+        margin-left: -$value !important;
+        margin-right: -$value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-y--neg#{$name} {
+        margin-top: -$value !important;
+        margin-bottom: -$value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-top--neg#{$name} {
+        margin-top: -$value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-right--neg#{$name} {
+        margin-right: -$value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-bottom--neg#{$name} {
+        margin-bottom: -$value !important;
+      }
+
+      .#{$bp_name}\:vads-u-margin-left--neg#{$name} {
+        margin-left: -$value !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Utilities

Utilities will be single-property to add flexibility and/or override default CSS properties of components, and allow the creation of UI patterns without needing the write new CSS. The margin utility is the first of many, but also the largest.

## What's in the PR
- Sass maps for breakpoints and 8pt spacing units
- Margin utility CSS 

## How the margin utility works
The margin utility is very similar to the one [USWDS 2.0 Margin Utility](https://v2.designsystem.digital.gov/utilities/margin-and-padding/). Rather than using `0` as a separator for half values (2.5, 1.5, 0.5), we are using `p`, resulting in `vads-u-margin--1p5`. 

### Responsive margins
The margin utility can be altered by breakpoint with a `:` preceded by a named breakpoint that matches our current Sass variables for breakpoints. 
```
<div class="vads-u-margin--1 medium-screen:vads-u-margin--2 large-screen:vads-u-margin--4">
```