### PR TITLE
[Sidenav] Fix for text falling on focus state

### DIFF
--- a/src/sass/modules/_m-nav-sidebar.scss
+++ b/src/sass/modules/_m-nav-sidebar.scss
@@ -152,6 +152,9 @@ $level-3-hover-padding: 8px 12px 8px 30px;
             border-color .1s ease-in-out 0s,
             padding .1s ease-in-out 0s;
         }
+        &:focus {
+          outline-offset: -2px;
+        }
       }
 
       i {
@@ -312,22 +315,6 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       a {
         font-size: 15px;
         padding: $level-2-default-padding;
-
-        // added to deal with accordian overflow
-        // and outline not showing correctly
-        &:focus {
-          width: 98% !important;
-          margin: 2px;
-        }
-      }
-    }
-
-    .usa-current {
-      // added to deal with accordian overflow
-      // and outline not showing correctly
-      &:focus {
-        width: 99% !important;
-        margin-top: 2px;
       }
     }
   }


### PR DESCRIPTION
We had some additional style rules applied during the focus state of the side navigation list items. Those rules were added because the gold outline around the focused item was getting cut off. This PR refines that by using `outline-offset` instead of `margin` and `width`.

## Before
The "and" here is seen wrapping to the next line on focus -
![image](https://user-images.githubusercontent.com/1915775/50930261-8640fa80-142d-11e9-9e49-5dc291fee152.png)

## After
Here's the same item with the changes in this PR -
![image](https://user-images.githubusercontent.com/1915775/50930300-a96baa00-142d-11e9-82ba-bb890f85a738.png)
