### PR TITLE
Fontawesome 5 upgrade 14460

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 1.18.0
+Version 2.0.0
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test-debug": "karma start --browsers Chrome"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
     "classnames": "^2.2.5",
     "foundation-sites": "5",
     "is-docker": "^1.1.0",
@@ -31,7 +32,6 @@
     "window-or-global": "^1.0.1"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
     "@frctl/fractal": "^1.1.7",
     "@frctl/mandelbrot": "^1.2.0",
     "@frctl/nunjucks": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "2.0.0-fa",
+  "version": "2.0.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "1.18.0",
+  "version": "2.0.0-fa",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "font-awesome": "4",
     "foundation-sites": "5",
     "is-docker": "^1.1.0",
     "lodash": "^4.5.1",
@@ -32,6 +31,7 @@
     "window-or-global": "^1.0.1"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
     "@frctl/fractal": "^1.1.7",
     "@frctl/mandelbrot": "^1.2.0",
     "@frctl/nunjucks": "^1.0.3",

--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -20,7 +20,7 @@ export default class AdditionalInfo extends React.Component {
     const { triggerText, children } = this.props;
     const iconClass = classNames({
       fa: true,
-      'fa-angle-down': true,
+      'fas fa-angle-down': true,
       open: this.state.open
     });
     const { tagName: TagName = 'span' } = this.props;

--- a/src/components/SortableTable/SortableTable.jsx
+++ b/src/components/SortableTable/SortableTable.jsx
@@ -31,8 +31,8 @@ class SortableTable extends React.Component {
     if (this.props.currentSort.value === field.value) {
       const iconClass = classNames({
         fa: true,
-        'fa-caret-down': this.props.currentSort.order === 'DESC',
-        'fa-caret-up': this.props.currentSort.order === 'ASC'
+        'fas fa-caret-down': this.props.currentSort.order === 'DESC',
+        'fas fa-caret-up': this.props.currentSort.order === 'ASC'
       });
 
       sortIcon = <i className={iconClass}></i>;

--- a/src/components/alerts/AlertBox/AlertBox.jsx
+++ b/src/components/alerts/AlertBox/AlertBox.jsx
@@ -45,7 +45,7 @@ class AlertBox extends React.Component {
     if (this.props.onCloseAlert) {
       closeButton = (
         <button className="va-alert-close" aria-label="Close notification" onClick={this.props.onCloseAlert}>
-          <i className="fa fa-close" aria-label="Close icon"></i>
+          <i className="far fa-times-circle" aria-label="Close icon"></i>
         </button>
       );
     }

--- a/src/components/alerts/AlertBox/AlertBox.jsx
+++ b/src/components/alerts/AlertBox/AlertBox.jsx
@@ -45,7 +45,7 @@ class AlertBox extends React.Component {
     if (this.props.onCloseAlert) {
       closeButton = (
         <button className="va-alert-close" aria-label="Close notification" onClick={this.props.onCloseAlert}>
-          <i className="far fa-times-circle" aria-label="Close icon"></i>
+          <i className="fas fa-times-circle" aria-label="Close icon"></i>
         </button>
       );
     }

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -71,7 +71,7 @@ Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">E
       <h3>Get help from Veterans Crisis Line</h3>
 
       <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal">
-        <i class="fa fa-times-circle va-overlay-close"></i>
+        <i class="fas fa-times-circle va-overlay-close"></i>
       </button>
 
       <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -71,7 +71,7 @@ Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">E
       <h3>Get help from Veterans Crisis Line</h3>
 
       <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal">
-        <i class="fa fa-close va-overlay-close"></i>
+        <i class="fa fa-times-circle va-overlay-close"></i>
       </button>
 
       <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/header/SearchMenu/SearchMenu.jsx
+++ b/src/components/header/SearchMenu/SearchMenu.jsx
@@ -54,7 +54,7 @@ class SearchMenu extends React.Component {
     const buttonClasses = classNames(
       this.props.cssClass,
       'va-btn-withicon',
-      'va-dropdown-trigger'
+      ''
     );
 
     const icon = <IconSearch color="#fff" role="presentation"/>;

--- a/src/components/header/vcl/vcl.njk
+++ b/src/components/header/vcl/vcl.njk
@@ -4,7 +4,7 @@
     <h3>Get help from Veterans Crisis Line</h3>
 
     <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal" onClick="showModal(this);">
-      <i class="far fa-times-circle va-overlay-close"></i>
+      <i class="fas fa-times-circle va-overlay-close"></i>
     </button>
 
     <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/header/vcl/vcl.njk
+++ b/src/components/header/vcl/vcl.njk
@@ -4,7 +4,7 @@
     <h3>Get help from Veterans Crisis Line</h3>
 
     <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal" onClick="showModal(this);">
-      <i class="fa fa-close va-overlay-close"></i>
+      <i class="far fa-times-circle va-overlay-close"></i>
     </button>
 
     <div class="va-overlay-body va-crisis-panel-body">

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -114,7 +114,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="far fa-times-circle"></i>
+        <i className="far fa-times"></i>
       </button>);
     }
 

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -114,7 +114,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="fa fa-close"></i>
+        <i className="far fa-times-circle"></i>
       </button>);
     }
 

--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -26,6 +26,12 @@
   font-style: normal;
 }
 
+.fa,
+.fas {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+}
+
 // ============ SETTINGS ============//
 // Order matters here! Please don't change it.
 @import "~uswds/src/stylesheets/core/variables";

--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -12,6 +12,7 @@
 
 // Font Awesome WOFF/WOFF2 fonts only
 @import "~@fortawesome/fontawesome-free/scss/variables";
+@import "~@fortawesome/fontawesome-free/scss/mixins";
 @import "~@fortawesome/fontawesome-free/scss/core";
 @import "~@fortawesome/fontawesome-free/scss/icons";
 @import "~@fortawesome/fontawesome-free/scss/animated";

--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -11,15 +11,16 @@
 @import "~foundation-sites/scss/foundation/components/visibility";
 
 // Font Awesome WOFF/WOFF2 fonts only
-@import "~font-awesome/scss/variables";
-@import "~font-awesome/scss/core";
-@import "~font-awesome/scss/icons";
-@import "~font-awesome/scss/animated";
+@import "~@fortawesome/fontawesome-free/scss/variables";
+@import "~@fortawesome/fontawesome-free/scss/core";
+@import "~@fortawesome/fontawesome-free/scss/icons";
+@import "~@fortawesome/fontawesome-free/scss/animated";
+
 @font-face {
-  font-family: "FontAwesome";
-  src: url("~font-awesome/fonts/fontawesome-webfont.woff2") format("woff2"),
-       url("~font-awesome/fonts/fontawesome-webfont.woff") format("woff"),
-       url("~font-awesome/fonts/fontawesome-webfont.eot") format("eot");
+  font-family: "Font Awesome 5 Free";
+  src: url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2") format("woff2"),
+       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff") format("woff"),
+       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot") format("eot");
   font-weight: normal;
   font-style: normal;
 }

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -9,7 +9,7 @@
 
   &::before {
     background: none;
-    font-family: "Font Awesome 5 free";
+    font-family: "Font Awesome 5 Free";
     font-size: 2rem;
     margin-right: 1.5rem;
     position: static;
@@ -98,6 +98,7 @@
     border-left-color: $color-gold;
 
     &::before {
+      font-family: "Font Awesome 5 Free";
       content: "\f071";
     }
 

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -127,6 +127,7 @@
 }
 
 .va-alert-close {
+  font-family: "Font Awesome 5 Free";
   background: transparent;
   color: $color-base;
   margin: 0;

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -9,7 +9,7 @@
 
   &::before {
     background: none;
-    font-family: "FontAwesome";
+    font-family: "Font Awesome 5 free";
     font-size: 2rem;
     margin-right: 1.5rem;
     position: static;

--- a/vets-sketchapp/styleguide.sketchplugin/Contents/Sketch/main.js
+++ b/vets-sketchapp/styleguide.sketchplugin/Contents/Sketch/main.js
@@ -34386,7 +34386,7 @@ var AlertBox = function (_React$Component) {
         closeButton = _react2.default.createElement(
           'button',
           { className: 'va-alert-close', 'aria-label': 'Close notification', onClick: this.props.onCloseAlert },
-          _react2.default.createElement('i', { className: 'fa fa-close', 'aria-label': 'Close icon' })
+          _react2.default.createElement('i', { className: 'fa fa-times-circle', 'aria-label': 'Close icon' })
         );
       }
 

--- a/vets-sketchapp/styleguide.sketchplugin/Contents/Sketch/main.js
+++ b/vets-sketchapp/styleguide.sketchplugin/Contents/Sketch/main.js
@@ -34386,7 +34386,7 @@ var AlertBox = function (_React$Component) {
         closeButton = _react2.default.createElement(
           'button',
           { className: 'va-alert-close', 'aria-label': 'Close notification', onClick: this.props.onCloseAlert },
-          _react2.default.createElement('i', { className: 'fa fa-times-circle', 'aria-label': 'Close icon' })
+          _react2.default.createElement('i', { className: 'far fa-times-circle', 'aria-label': 'Close icon' })
         );
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@fortawesome/fontawesome-free@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.6.3.tgz#61c122c420d7a91613f393d6a06e5a4c6ae6abf3"
+  integrity sha512-s5PLdI9NYgjBvfrv6rhirPHlAHWx+Sfo/IjsAeiXYfmemC/GSjwsyz1wLnGPazbLPXWfk62ks980o9AmsxYUEQ==
+
 "@frctl/fractal@^1.0.0", "@frctl/fractal@^1.0.0-rc.1", "@frctl/fractal@^1.1.0-alpha.0", "@frctl/fractal@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@frctl/fractal/-/fractal-1.1.7.tgz#7f2e0874ef88b0f611a8d594965e3510f8c9ada3"
@@ -3518,10 +3523,6 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
-
-font-awesome@4:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
This PR is an upgrade from Font Awesome 4 icon library to Font Awesome 5. 

The icon library upgrade is reflected sitewide on the homepage, hub pages, modals, and other areas. 

Icon updates on the homepage alert banner, hub links containers:
![screen shot 2019-01-11 at 3 42 48 pm](https://user-images.githubusercontent.com/11021491/51058693-97b60e00-15b7-11e9-8197-da3aa5775dcd.png)
homepage benefits rows and homepage buttons
![screen shot 2019-01-11 at 3 44 20 pm](https://user-images.githubusercontent.com/11021491/51058749-cd5af700-15b7-11e9-8c22-2e60e151aa8e.png)

![screen shot 2019-01-11 at 3 48 39 pm](https://user-images.githubusercontent.com/11021491/51058923-6558e080-15b8-11e9-83cf-7ec4644b4213.png)


Before:
![screen shot 2019-01-11 at 3 52 39 pm](https://user-images.githubusercontent.com/11021491/51059084-fdef6080-15b8-11e9-8c85-e7497d6a3555.png)

After:
![screen shot 2019-01-11 at 3 54 24 pm](https://user-images.githubusercontent.com/11021491/51059152-368f3a00-15b9-11e9-821a-48b76959f9b0.png)

Veteran Crisis Modal before:
![screen shot 2019-01-11 at 4 19 57 pm](https://user-images.githubusercontent.com/11021491/51060206-de5a3700-15bc-11e9-9c03-a993c32fab40.png)

Veteran Crisis Modal after: 
![screen shot 2019-01-11 at 4 22 18 pm](https://user-images.githubusercontent.com/11021491/51060251-1a8d9780-15bd-11e9-900e-ecf8206b2c6e.png)

This PR needs to be pulled alongside this corresponding vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/9369
