### PR TITLE
Fix modal display on Fractal site

### DIFF
--- a/src/components/modal/modal.config.yml
+++ b/src/components/modal/modal.config.yml
@@ -2,39 +2,7 @@ label: Modal
 status: wip
 order: 10
 
-variants:
-  - name: default
-    context:
-      componentSourcePath: 'Modal.jsx'
-      id: default
-      title: 'Default Modal'
-      status: ''
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'
-  - name: Info
-    context:
-      componentSourcePath: 'Modal.jsx'
-      id: info
-      title: 'Info Modal'
-      status: 'info'
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'
-  - name: Success
-    context:
-      componentSourcePath: 'Modal.jsx'
-      id: success
-      title: 'Success Modal'
-      status: 'success'
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'
-  - name: Warning
-    context:
-      componentSourcePath: 'Modal.jsx'
-      id: warning
-      title: 'Warning Modal'
-      status: 'warning'
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'
-  - name: Error
-    context:
-      componentSourcePath: 'Modal.jsx'
-      id: error
-      title: 'Error Modal'
-      status: 'error'
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'
+context:
+  componentSourcePath: 'Modal.jsx'
+  id: default
+  content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis.'

--- a/src/components/modal/modal.njk
+++ b/src/components/modal/modal.njk
@@ -1,15 +1,56 @@
 import React from 'react';
 import Modal from './Modal';
 
-export default function ModalExample(props) {
-  return (
-    <Modal
-      title={props.title}
-      id={props.id}
-      status={props.status}
-      visible
-      onClose={() => {}}>
-      {props.content}
-    </Modal>
-  );
+export default class ModalExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showDefault: false,
+      showInfo: false,
+      showWarning: false,
+      showError: false
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <button onClick={() => this.setState({showDefault: true})}>Show Default Modal</button>
+        <Modal
+          title="Default Modal"
+          id="default"
+          visible={this.state.showDefault}
+          onClose={() => this.setState({showDefault: false})}>
+          {this.props.content}
+        </Modal>
+        <button onClick={() => this.setState({showInfo: true})}>Show Info Modal</button>
+        <Modal
+          title="Info Modal"
+          id="info"
+          status="info"
+          visible={this.state.showInfo}
+          onClose={() => this.setState({showInfo: false})}>
+          {this.props.content}
+        </Modal>
+        <button onClick={() => this.setState({showError: true})}>Show Error Modal</button>
+        <Modal
+          title="Error Modal"
+          id="error"
+          status="error"
+          visible={this.state.showError}
+          onClose={() => this.setState({showError: false})}>
+          {this.props.content}
+        </Modal>
+        <button onClick={() => this.setState({showWarning: true})}>Show Warning Modal</button>
+        <Modal
+          title="Warning Modal"
+          id="warning"
+          status="warning"
+          visible={this.state.showWarning}
+          onClose={() => this.setState({showWarning: false})}>
+          {this.props.content}
+        </Modal>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
Modals aren't displaying properly on the Fractal site, locally or on GH pages. This removes the variants and puts the examples in one page:

![screen shot 2019-01-15 at 11 20 51 am](https://user-images.githubusercontent.com/634932/51193789-a9e5c400-18b7-11e9-8046-84704b7bfef7.png)

Fixes #218 