### PR TITLE
[MegaMenu] Increase height for new hub illustrations

### DIFF
--- a/module-readme.md
+++ b/module-readme.md
@@ -1,4 +1,4 @@
-Version 2.0.0
+Version 2.0.1
 
 This module contains reusable react components from [vets-website](https://github.com/department-of-veterans-affairs/vets-website) housed in its design system [repo](https://github.com/department-of-veterans-affairs/design-system).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -1,3 +1,7 @@
+$vetnav-panel-height-desktop: 490px;
+$vetnav-panel-height: 380px;
+$marketing-container-height: 380px;
+
 #mega-menu {
   flex: 1 0 100%;
   color: $color-primary;
@@ -114,7 +118,7 @@
 
     .vetnav-panel {
       box-shadow: 0 7px 25px -11px $color-black;
-      height: 480px;
+      height: 490px;
       width: 1008px;
       left: 0;
 
@@ -206,7 +210,7 @@
 
   .mm-marketing-container {
     background-color: $color-white;
-    height: 380px;
+    height: $marketing-container-height;
     overflow: hidden;
 
     &.mm-marketing-gray {
@@ -258,7 +262,7 @@
   }
 
   .mm-marketing-container {
-    height: 350px;
+    height: $marketing-container-height;
 
     p {
       margin-top: 5px;
@@ -278,7 +282,7 @@
 
     .vetnav-panel {
       width: $medium-large-screen;
-      height: 380px;
+      height: $vetnav-panel-height;
     }
 
     .column-one {
@@ -322,7 +326,7 @@
   @include media($small-desktop-screen) {
     .vetnav-panel {
       width: $small-desktop-screen;
-      height: 460px;
+      height: $vetnav-panel-height-desktop;
     }
 
     .panel-bottom-link {

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -118,7 +118,7 @@ $marketing-container-height: 380px;
 
     .vetnav-panel {
       box-shadow: 0 7px 25px -11px $color-black;
-      height: 490px;
+      height: $vetnav-panel-height-desktop;
       width: 1008px;
       left: 0;
 

--- a/src/sass/modules/_m-megamenu.scss
+++ b/src/sass/modules/_m-megamenu.scss
@@ -114,7 +114,7 @@
 
     .vetnav-panel {
       box-shadow: 0 7px 25px -11px $color-black;
-      height: 460px;
+      height: 480px;
       width: 1008px;
       left: 0;
 
@@ -206,7 +206,7 @@
 
   .mm-marketing-container {
     background-color: $color-white;
-    height: 350px;
+    height: 380px;
     overflow: hidden;
 
     &.mm-marketing-gray {


### PR DESCRIPTION
Blocks https://github.com/department-of-veterans-affairs/vagov-content/pull/232

The new hub illustrations have a different aspect ratio than the former, causing text in the marketing containers to get cut off. See [here](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13822#issuecomment-456157255) for more context. This PR increases the height of the MegaMenu to account for that.

![image](https://user-images.githubusercontent.com/1915775/51499255-862eec00-1d97-11e9-968b-d2d892f1903d.png)

These illustrations are another part of upgrading Font Awesome, as the icons used in the PNGs are from FA.
