### PR TITLE
added class in core.scss to recognize brand icons

### DIFF
--- a/src/sass/core.scss
+++ b/src/sass/core.scss
@@ -1,0 +1,80 @@
+@charset "UTF-8";
+// Note: if you add variable files in here, make sure you updated shared-variables.scss
+
+//============ VENDOR PARTIALS ==============//
+@import "~uswds/src/stylesheets/lib/bourbon";
+@import "~uswds/src/stylesheets/lib/neat";
+@import "~uswds/src/stylesheets/lib/normalize"; // Currently 3.0.3
+
+@import "~foundation-sites/scss/foundation/components/grid";
+@import "~foundation-sites/scss/foundation/components/block-grid";
+@import "~foundation-sites/scss/foundation/components/visibility";
+
+// Font Awesome WOFF/WOFF2 fonts only
+@import "~@fortawesome/fontawesome-free/scss/variables";
+@import "~@fortawesome/fontawesome-free/scss/mixins";
+@import "~@fortawesome/fontawesome-free/scss/core";
+@import "~@fortawesome/fontawesome-free/scss/icons";
+@import "~@fortawesome/fontawesome-free/scss/animated";
+
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  src: url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2") format("woff2"),
+       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff") format("woff"),
+       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot") format("eot");
+  font-weight: normal;
+  font-style: normal;
+}
+
+.fa,
+.fab,
+.fas {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+}
+
+// ============ SETTINGS ============//
+// Order matters here! Please don't change it.
+@import "~uswds/src/stylesheets/core/variables";
+
+// A VA partial. Here so that we can override the
+// USWDS breakpoint and grid variables from above before
+// the grid, alerts, etc are loaded.
+@import "base/b-variables";
+@import "base/b-breakpoints";
+
+@import "~uswds/src/stylesheets/core/fonts";
+@import "~uswds/src/stylesheets/core/grid";
+@import "~uswds/src/stylesheets/core/utilities";
+@import "~uswds/src/stylesheets/core/base";
+
+// ---- U.S. WEB DESIGN STANDARDS ELEMENTS/COMPONENTS --- //
+@import "~uswds/src/stylesheets/elements/buttons";
+@import "~uswds/src/stylesheets/elements/inputs";
+@import "~uswds/src/stylesheets/elements/labels";
+@import "~uswds/src/stylesheets/elements/list";
+@import "~uswds/src/stylesheets/elements/table";
+@import "~uswds/src/stylesheets/elements/typography";
+@import "~uswds/src/stylesheets/components/accordions";
+@import "~uswds/src/stylesheets/components/alerts";
+@import "~uswds/src/stylesheets/components/forms";
+@import "~uswds/src/stylesheets/components/sidenav";
+@import "~uswds/src/stylesheets/components/media-block";
+@import "~uswds/src/stylesheets/components/banner";
+
+// ----- VA BASE (VARIABLES/HELPERS) ---- //
+@import "base/b-element-overrides";
+@import "base/b-mixins";
+@import "base/b-functions";
+@import "base/b-utils";
+@import "base/b-font-faces";
+
+// ----- VA GENERAL (MAIN FILE/OTHER) ---- //
+@import "base/va";
+@import "base/focus";
+
+// ----- VA UTILITIES (UTILITIY OOCSS) ---- //
+@import "utilities/display";
+@import "utilities/margins";
+@import "utilities/padding";
+@import "utilities/visibility";


### PR DESCRIPTION
This PR adds `.fab` class to `core.scss` to include the brand icons in Font Awesome 5.

Note: I was not able to test this locally because of an earlier PR that needed to be merged first before my local instance. https://github.com/department-of-veterans-affairs/vets-website/pull/9434

