### PR TITLE
Font Awesome - Adds Brand, Regular icon sets

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "3.0.0-FA-0.0.1",
+  "version": "3.0.0-FA-0.0.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "3.0.0-FA",
+  "version": "3.0.0-FA-0.0.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "3.0.0",
+  "version": "3.0.0-FA",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -19,8 +19,8 @@ export default class AdditionalInfo extends React.Component {
   render() {
     const { triggerText, children } = this.props;
     const iconClass = classNames({
-      fa: true,
-      'fas fa-angle-down': true,
+      fas: true,
+      'fa-angle-down': true,
       open: this.state.open
     });
     const { tagName: TagName = 'span' } = this.props;

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -114,7 +114,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="far fa-times" aria-hidden="true"></i>
+        <i className="fas fa-times" aria-hidden="true"></i>
       </button>);
     }
 

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -114,7 +114,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="fas fa-times" aria-hidden="true"></i>
+        <i className="far fa-times" aria-hidden="true"></i>
       </button>);
     }
 

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.0-FA-0.0.1",
+  "version": "3.0.0-FA-0.0.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -24,11 +24,11 @@
     "url": "https://github.com/department-of-veterans-affairs/design-system/issues"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
-    "foundation-sites": "5",
     "moment": "^2.23.0"
   },
   "peerDependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
+    "foundation-sites": "5",
     "uswds": "^1.4.2"
   }
 }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -24,11 +24,11 @@
     "url": "https://github.com/department-of-veterans-affairs/design-system/issues"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
     "foundation-sites": "5",
     "moment": "^2.23.0"
   },
   "peerDependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
     "uswds": "^1.4.2"
   }
 }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.0-FA-0.0.2",
+  "version": "3.0.0-FA-0.0.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -24,11 +24,11 @@
     "url": "https://github.com/department-of-veterans-affairs/design-system/issues"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
     "foundation-sites": "5",
     "moment": "^2.23.0"
   },
   "peerDependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
     "uswds": "^1.4.2"
   }
 }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -24,6 +24,8 @@
     "url": "https://github.com/department-of-veterans-affairs/design-system/issues"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
+    "foundation-sites": "5",
     "moment": "^2.23.0"
   },
   "peerDependencies": {

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.0-FA",
+  "version": "3.0.0-FA-0.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.0",
+  "version": "3.0.0-FA",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -27,6 +27,7 @@
 }
 
 .fa,
+.fab,
 .fas {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900;

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -10,10 +10,7 @@
 @import "~foundation-sites/scss/foundation/components/block-grid";
 @import "~foundation-sites/scss/foundation/components/visibility";
 
-// Font Awesome WOFF/WOFF2 fonts only
-$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
-
-@import "~@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "~@fortawesome/fontawesome-free/scss/fontawesome";
 @import "~@fortawesome/fontawesome-free/scss/solid";
 @import "~@fortawesome/fontawesome-free/scss/brands";
 @import "~@fortawesome/fontawesome-free/scss/regular";

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -16,22 +16,69 @@
 @import "~@fortawesome/fontawesome-free/scss/core";
 @import "~@fortawesome/fontawesome-free/scss/icons";
 @import "~@fortawesome/fontawesome-free/scss/animated";
+// @import "~@fortawesome/fontawesome-free/scss/solid";
+// @import "~@fortawesome/fontawesome-free/scss/brands";
+// @import "~@fortawesome/fontawesome-free/scss/regular"
 
+// ============Font Awesome 5 Solid Start============
 @font-face {
-  font-family: "Font Awesome 5 Free";
-  src: url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2") format("woff2"),
-       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff") format("woff"),
-       url("~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot") format("eot");
-  font-weight: normal;
+  font-family: 'Font Awesome 5 Free';
   font-style: normal;
+  font-weight: 900;
+  src: url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot') format("eot");
+  src: url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2') format('woff2'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff') format('woff'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.ttf') format('truetype'),
+  // url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg#fontawesome') format('svg'), This breaks everything
 }
 
 .fa,
-.fab,
 .fas {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900;
 }
+// ============Font Awesome 5 Solid End============
+
+
+// ============Font Awesome 5 Brands Start===========
+@font-face {
+  font-family: 'Font Awesome 5 Brands';
+  font-style: normal;
+  font-weight: normal;
+  src: url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.eot');
+  src: url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.eot?#iefix') format('embedded-opentype'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff2') format('woff2'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff') format('woff'),
+  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.ttf') format('truetype'),
+  // url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.svg#fontawesome') format('svg'); This breaks everything
+}
+
+.fab {
+  font-family: 'Font Awesome 5 Brands';
+}
+// ============Font Awesome 5 Brands End============
+
+
+// ============Font Awesome 5 Regular Start============
+
+// @font-face {
+//   font-family: "Font Awesome 5 Free";
+//   src: url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff2") format("woff2"),
+//        url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff") format("woff"),
+//        url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.eot") format("eot");
+//   font-weight: 400;
+//   font-style: normal;
+// }
+
+
+// .far {
+//   font-family: 'Font Awesome 5 Free';
+//   font-weight: 400;
+// }
+
+// ============Font Awesome 5 Regular End============
+
 
 // ============ SETTINGS ============//
 // Order matters here! Please don't change it.

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -11,74 +11,12 @@
 @import "~foundation-sites/scss/foundation/components/visibility";
 
 // Font Awesome WOFF/WOFF2 fonts only
-@import "~@fortawesome/fontawesome-free/scss/variables";
-@import "~@fortawesome/fontawesome-free/scss/mixins";
-@import "~@fortawesome/fontawesome-free/scss/core";
-@import "~@fortawesome/fontawesome-free/scss/icons";
-@import "~@fortawesome/fontawesome-free/scss/animated";
-// @import "~@fortawesome/fontawesome-free/scss/solid";
-// @import "~@fortawesome/fontawesome-free/scss/brands";
-// @import "~@fortawesome/fontawesome-free/scss/regular"
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
-// ============Font Awesome 5 Solid Start============
-@font-face {
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-weight: 900;
-  src: url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot') format("eot");
-  src: url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff2') format('woff2'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.woff') format('woff'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.ttf') format('truetype'),
-  // url('~@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg#fontawesome') format('svg'), This breaks everything
-}
-
-.fa,
-.fas {
-  font-family: 'Font Awesome 5 Free';
-  font-weight: 900;
-}
-// ============Font Awesome 5 Solid End============
-
-
-// ============Font Awesome 5 Brands Start===========
-@font-face {
-  font-family: 'Font Awesome 5 Brands';
-  font-style: normal;
-  font-weight: normal;
-  src: url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.eot');
-  src: url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.eot?#iefix') format('embedded-opentype'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff2') format('woff2'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.woff') format('woff'),
-  url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.ttf') format('truetype'),
-  // url('~@fortawesome/fontawesome-free/webfonts/fa-brands-400.svg#fontawesome') format('svg'); This breaks everything
-}
-
-.fab {
-  font-family: 'Font Awesome 5 Brands';
-}
-// ============Font Awesome 5 Brands End============
-
-
-// ============Font Awesome 5 Regular Start============
-
-// @font-face {
-//   font-family: "Font Awesome 5 Free";
-//   src: url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff2") format("woff2"),
-//        url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff") format("woff"),
-//        url("~@fortawesome/fontawesome-free/webfonts/fa-regular-400.eot") format("eot");
-//   font-weight: 400;
-//   font-style: normal;
-// }
-
-
-// .far {
-//   font-family: 'Font Awesome 5 Free';
-//   font-weight: 400;
-// }
-
-// ============Font Awesome 5 Regular End============
-
+@import "~@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "~@fortawesome/fontawesome-free/scss/solid";
+@import "~@fortawesome/fontawesome-free/scss/brands";
+@import "~@fortawesome/fontawesome-free/scss/regular";
 
 // ============ SETTINGS ============//
 // Order matters here! Please don't change it.

--- a/packages/formation/sass/full.scss
+++ b/packages/formation/sass/full.scss
@@ -2,6 +2,7 @@
  * Complete set of Formation styles
  */
 
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 $font-path: "~uswds/src/fonts";
 $image-path: "~uswds/src/img";
 @import "core";

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -13,6 +13,7 @@
     font-size: 2rem;
     margin-right: 1.5rem;
     position: static;
+    font-weight: 900;
   }
 
   // &-body would not have had high enough precedence.
@@ -99,6 +100,7 @@
 
     &::before {
       font-family: "Font Awesome 5 Free";
+      font-weight: 900;
       content: "\f071";
     }
 

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -100,7 +100,6 @@
 
     &::before {
       font-family: "Font Awesome 5 Free";
-      font-weight: 900;
       content: "\f071";
     }
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -43,7 +43,7 @@ module.exports = {
         }
       },
       {
-        test: /\.(ttf|eot|woff|woff2|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(ttf|eot|woff|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: {
           loader: 'file-loader',
           options: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -39,11 +39,11 @@ module.exports = {
       {
         test: /\.svg/,
         use: {
-          loader: 'svg-url-loader'
+          loader: 'svg-url-loader?limit=1024'
         }
       },
       {
-        test: /\.(ttf|eot|woff|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(ttf|eot|woff|woff2|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: {
           loader: 'file-loader',
           options: {


### PR DESCRIPTION
This PR adds .fab class to core.scss to include the brand icons in Font Awesome 5.

Note: I was not able to test this locally because of an earlier PR that needed to be merged first before my local instance. department-of-veterans-affairs/vets-website#9434