### PR TITLE
Create Flex grid

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@department-of-veterans-affairs/formation",
+<<<<<<< HEAD
   "version": "3.0.1",
+=======
+  "version": "3.1.0",
+>>>>>>> update version
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-<<<<<<< HEAD
   "version": "3.0.1",
-=======
-  "version": "3.1.0",
->>>>>>> update version
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -149,3 +149,17 @@
     outline-offset: 0;
   }
 }
+
+
+
+// Flexbox columns
+@mixin flexbox-col($size) {
+  flex: 0 0 percentage($size / $grid-columns);
+  max-width: percentage($size / $grid-columns); // IE10+ and Firefox
+}
+
+@mixin equal-width-flexbox-col() {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%;
+}

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -140,3 +140,8 @@ $spacers: (
   8:    $multiple * 8,
   9:    $multiple * 9
 ) !default;
+
+//====================================
+// Grid columns
+//===================================
+$grid-columns: 12 !default;

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -72,6 +72,9 @@
 @import "base/va";
 @import "base/focus";
 
+// ----- Layout ---- //
+@import "layout/flex-grid";
+
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
 @import "utilities/display";
 @import "utilities/margins";

--- a/packages/formation/sass/layout/_flex-grid.scss
+++ b/packages/formation/sass/layout/_flex-grid.scss
@@ -1,0 +1,69 @@
+// Grid container
+.vads-l-grid-container,
+.vads-l-grid-container--full {
+  @include outer-container($site-max-width);
+}
+
+.vads-l-grid-container {
+  @include padding(null $site-margins-mobile);
+
+  @include media($medium-screen) {
+    @include padding(null $site-margins);
+  }
+}
+
+.vads-l-grid-container--full {
+  padding: 0;
+}
+
+.vads-l-row {
+  display: flex;
+  flex-wrap: wrap;
+  min-width: 100%;
+}
+
+%grid-column {
+  box-sizing: border-box;
+  min-height: 1px; // Prevent columns from collapsing when empty
+  min-width: 0; // Resize columns as expected (https://css-tricks.com/flexbox-truncated-text/)
+  position: relative;
+  width: 100%;
+}
+
+@for $i from 1 through $grid-columns {
+  // Example: vads-l-col--6
+  .vads-l-col--#{$i} {
+    @extend %grid-column;
+  }
+}
+
+.vads-l-col {
+  @extend %grid-column;
+  @include equal-width-flexbox-col;
+}
+
+@for $i from 1 through $grid-columns {
+  // Example: vads-l-col--12
+  .vads-l-col--#{$i} {
+    @include flexbox-col($i);
+  }
+}
+
+// Breakpoint prefix grids. All
+@each $bp_name, $bp_value in $breakpoints {
+
+  @media (min-width: $bp_value) {
+    // Provide breakpoint classes for equal-width columns
+    // Example: vads-l-lg-col
+    .#{$bp_name}\:vads-l-col {
+      @include equal-width-flexbox-col;
+    }
+
+    @for $i from 1 through $grid-columns {
+      // Example: vads-l-lg-col--12
+      .#{$bp_name}\:vads-l-col--#{$i} {
+        @include flexbox-col($i);
+      }
+    }
+  }
+}

--- a/packages/formation/sass/modules/_m-form-process.scss
+++ b/packages/formation/sass/modules/_m-form-process.scss
@@ -65,6 +65,14 @@
 
 // Overriding the accordion button styles that are too broad
 .form-review-panel {
+  @media (max-width: $medium-screen) {
+    .form-review-array {
+      .edit-btn {
+        width: 100%;
+        text-align: center;
+      }
+    }
+  }
   button:not(.usa-button-unstyled) {
     background-image: none;
     background-color: $color-primary;


### PR DESCRIPTION
This will create a flexbox grid outlined in https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16501

The flexbox grid will live with the USWDS grid, but it provides a little more flexibility due to the features available in flexbox. Once a flexbox utility is created, there will be an even wider suite of options.

More documentation on how the flexbox grid works, including responsive examples, can be found on the documentation site:
https://department-of-veterans-affairs.github.io/vets-design-system-documentation/layout/flexbox-grid.html