### PR TITLE
Add bash command to skip docs build

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "if [ -z \"$GITHUB_API_KEY\" ]; then echo \"No API key, skipping doc build\"; else gatsby build; fi",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",


### PR DESCRIPTION
The build fails unless you have a GH api key set up, but we're not quite to the point where we have that process all documented. For now, this will skip the gatsby build if you don't have one set.