### PR TITLE
Updates and fixes for alert modals

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -34,7 +34,7 @@
     "window-or-global": "^1.0.1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^2.0.0",
+    "@department-of-veterans-affairs/formation": "^4.0.0",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -159,7 +159,6 @@ Modal.propTypes = {
   cssClass: PropTypes.string,
   /**
    * Id of the modal, used for aria attributes.
-   * It will be auto-generated if not provided.
    */
   id: PropTypes.string,
   /**

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -1,21 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import _ from 'lodash';
 
 const ESCAPE_KEY = 27;
 
 class Modal extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      lastFocus: null,
-    };
+    this.state = { lastFocus: null };
   }
 
   componentDidMount() {
-    if (this.props.visible) {
-      this.setupModal();
-    }
+    this.id = this.props.id || _.uniqueId('va-modal-');
+    if (this.props.visible) this.setupModal();
   }
 
   componentDidUpdate(prevProps) {
@@ -86,26 +84,29 @@ class Modal extends React.Component {
     }
   }
 
-  render() {
-    const { id, title, visible } = this.props;
-    const alertClass = classNames(
-      'usa-alert',
-      `usa-alert-${this.props.status}`
-    );
+  renderAlertActions = () => {
+    const { primaryButton, secondaryButton } = this.props;
+    if (!primaryButton && !secondaryButton) return null;
 
-    const titleClass = classNames(
-      'va-modal-title',
-      `va-modal-title-${this.props.status}`
-    );
-
-    const modalCss = classNames('va-modal', this.props.cssClass);
-    const modalTitle = title && (
-      <div className={alertClass}>
-        <h3 id={`${id}-title`} className={titleClass}>{title}</h3>
+    return (
+      <div className="alert-actions">
+        {primaryButton && <button className="usa-button" onClick={primaryButton.action}>{primaryButton.text}</button>}
+        {secondaryButton && <button className="usa-button-secondary" onClick={secondaryButton.action}>{secondaryButton.text}</button>}
       </div>
     );
+  };
+
+  render() {
+    const { status, title, visible } = this.props;
 
     if (!visible) { return <div/>; }
+
+    const modalCss = classNames(
+      'va-modal',
+      { 'va-modal-alert': status },
+      { [`va-modal-${status}`]: status },
+      this.props.cssClass,
+    );
 
     let closeButton;
     if (!this.props.hideCloseButton) {
@@ -119,18 +120,15 @@ class Modal extends React.Component {
     }
 
     return (
-      <div className={modalCss} id={id} role="alertdialog" aria-labelledby={`${id}-title`}>
+      <div className={modalCss} id={this.id} role="alertdialog" aria-labelledby={`${this.id}-title`}>
         <div className="va-modal-inner" ref={el => { this.element = el; }}>
-          {modalTitle}
           {closeButton}
           <div className="va-modal-body" role="document">
+            {title && <h3 id={`${this.id}-title`} className="va-modal-title">{title}</h3>}
             <div>
               {this.props.contents || this.props.children}
             </div>
-            <div className="alert-actions">
-              {this.props.primaryButton && <button className="usa-button" onClick={this.props.primaryButton.action}>{this.props.primaryButton.text}</button>}
-              {this.props.secondaryButton && <button className="usa-button-secondary" onClick={this.props.secondaryButton.action}>{this.props.secondaryButton.text}</button>}
-            </div>
+            {this.renderAlertActions()}
           </div>
 
         </div>
@@ -161,18 +159,19 @@ Modal.propTypes = {
    */
   cssClass: PropTypes.string,
   /**
-   * Id of the modal, used for aria attributes
+   * Id of the modal, used for aria attributes.
+   * It will be auto-generated if not provided.
    */
   id: PropTypes.string,
   /**
-   * primary button text and action
+   * Primary button text and action
    */
   primaryButton: PropTypes.shape({
     text: PropTypes.string.isRequired,
     action: PropTypes.func.isRequired,
   }),
   /**
-   * secondary button text and action
+   * Secondary button text and action
    */
   secondaryButton: PropTypes.shape({
     text: PropTypes.string.isRequired,

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import _ from 'lodash';
 
 const ESCAPE_KEY = 27;
 
@@ -12,7 +11,6 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
-    this.id = this.props.id || _.uniqueId('va-modal-');
     if (this.props.visible) this.setupModal();
   }
 
@@ -97,11 +95,12 @@ class Modal extends React.Component {
   };
 
   render() {
-    const { status, title, visible } = this.props;
+    if (!this.props.visible) return null;
 
-    if (!visible) { return <div/>; }
+    const { id, status, title } = this.props;
+    const titleId = title && `${id || 'va-modal'}-title`;
 
-    const modalCss = classNames(
+    const modalClass = classNames(
       'va-modal',
       { 'va-modal-alert': status },
       { [`va-modal-${status}`]: status },
@@ -120,11 +119,11 @@ class Modal extends React.Component {
     }
 
     return (
-      <div className={modalCss} id={this.id} role="alertdialog" aria-labelledby={`${this.id}-title`}>
+      <div className={modalClass} id={id} role="alertdialog" aria-labelledby={titleId}>
         <div className="va-modal-inner" ref={el => { this.element = el; }}>
           {closeButton}
           <div className="va-modal-body" role="document">
-            {title && <h3 id={`${this.id}-title`} className="va-modal-title">{title}</h3>}
+            {title && <h3 id={titleId} className="va-modal-title">{title}</h3>}
             <div>
               {this.props.contents || this.props.children}
             </div>

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -114,7 +114,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="fas fa-times" aria-hidden="true"></i>
+        <i className="fas fa-times-circle" aria-hidden="true"></i>
       </button>);
     }
 
@@ -158,7 +158,7 @@ Modal.propTypes = {
    */
   cssClass: PropTypes.string,
   /**
-   * Id of the modal, used for aria attributes.
+   * Id of the modal, used for aria attributes
    */
   id: PropTypes.string,
   /**

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "3.14.0",
+  "version": "4.0.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -59,8 +59,6 @@ $color-warning-message:      #fac922; // Used for Disability benefits
 $color-gray-light-alt:       #eee;
 $color-va-alert-bg:          $color-gray-lightest;
 $color-va-modal-bg:          rgba($color-gray-dark, .8);
-//$color-va-modal-bg--gi:      rgba($color-gray-dark, .8);
-$color-va-modal-close:       rgba($color-base, .8);
 
 $color-inset-bg:             #e0f3f8;
 $color-gibill-accent:        #fff1d2; // TODO: Replace with $color-gold-lightest;

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -57,6 +57,7 @@ $color-va-accent:            #988530; // New gold "metal" acccent
 $color-gold:                 #fdb81e;
 $color-warning-message:      #fac922; // Used for Disability benefits
 $color-gray-light-alt:       #eee;
+$color-va-alert-bg:          $color-gray-lightest;
 $color-va-modal-bg:          rgba($color-gray-dark, .8);
 //$color-va-modal-bg--gi:      rgba($color-gray-dark, .8);
 $color-va-modal-close:       rgba($color-base, .8);

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -57,7 +57,6 @@ $color-va-accent:            #988530; // New gold "metal" acccent
 $color-gold:                 #fdb81e;
 $color-warning-message:      #fac922; // Used for Disability benefits
 $color-gray-light-alt:       #eee;
-$color-va-alert-bg:          $color-gray-lightest;
 $color-va-modal-bg:          rgba($color-gray-dark, .8);
 
 $color-inset-bg:             #e0f3f8;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -211,7 +211,6 @@ table {
 // Logo and Header
 .header {
   background: $color-primary-darkest;
-  color: $color-white;
   clear: both;
   margin: 0;
   padding: 0;

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -1,6 +1,6 @@
 .usa-alert {
   background: none;
-  background-color: $color-gray-lightest;
+  background-color: $color-va-alert-bg;
   border-left-style: solid;
   border-left-width: 10px;
   display: table;
@@ -99,7 +99,6 @@
     border-left-color: $color-gold;
 
     &::before {
-      font-family: "Font Awesome 5 Free";
       content: "\f071";
     }
 

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -1,6 +1,6 @@
 .usa-alert {
   background: none;
-  background-color: $color-va-alert-bg;
+  background-color: $color-gray-lightest;
   border-left-style: solid;
   border-left-width: 10px;
   display: table;

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -1,5 +1,4 @@
 // Styles for application modals
-// Used in prescriptions, messaging.
 
 // Hide initially, to be shown if url contains #modal
 // Alternatively, modal.hide() in content/includes/modal.html
@@ -22,97 +21,19 @@
     overflow-y: scroll;
   }
 
-  // error standardization
-  .usa-alert {
-    .va-modal-title-undefined {
-      padding: 0.5rem !important;
-    }
-
-    &-undefined {
-      background: $color-white;
-      padding-left: 2rem;
-    }
-
-    &:before {
-      content: none;
-    }
-  }
-
   .va-modal-body {
     p:first-of-type {
       margin-top: 0;
     }
   }
 
-  // "Forked" modal styles
-  &-split {
-    .va-modal-inner {
-      min-width: 710px;
-
-      @include media-maxwidth($small-screen) {
-        top: 0%;
-        transform: translateY(0%);
-        min-width: auto;
-        .usa-button-primary {
-          display: block;
-        }
-      }
-    }
-    &-container {
-      display: flex;
-    }
-    &-left,
-    &-right {
-      flex: 1;
-      padding: 0 20px;
-      @include media-maxwidth($small-screen) {
-        flex: none;
-        padding: 0;
-      }
-    }
-    &-title {
-      margin-top: 0;
-    }
-    &-list {
-      margin-top: 10px;
-    }
-    &-divider {
-      background: $color-primary-alt-lightest;
-      width: 3px;
-
-      // Horizontally aligned "OR" divider for mobile
-      @include media-maxwidth($small-screen) {
-        width: 100%;
-        height: 3px;
-        display: flex;
-        margin: 25px 0;
-        justify-content: center;
-        align-items: center;
-        &:after {
-          text-align: center;
-          content: "OR";
-          font-size: 20px;
-          font-weight: bold;
-          padding: 5px 10px;
-          background: $color-white;
-        }
-      }
-    }
-
-    @include media-maxwidth($small-screen) {
-      &-container {
-        flex-flow: column;
-      }
-    }
+  .alert-actions {
+    margin-top: 1.5rem;
   }
 
   &-title {
-    // background: $color-primary-darkest;
-    // color: $color-white;
-    // font-size: 2.4rem;
     margin: 0;
-    // Abusing important until #content .section h3 is cleared up.
-    padding: 0.5rem 2rem !important;
+    margin-bottom: 1.5rem;
   }
 
   &-inner {
@@ -164,6 +85,68 @@
       }
     }
   }
+
+  &-alert {
+    .va-modal-inner {
+      max-width: 60rem;
+    }
+
+    .va-modal-body {
+      background: $color-va-alert-bg;
+      border-left-style: solid;
+      border-left-width: 10px;
+      padding: 2rem 4rem;
+    }
+
+    .va-modal-title {
+      &::before {
+        font-family: "Font Awesome 5 Free";
+        margin-right: 1.5rem;
+      }
+    }
+  }
+
+  &-info {
+    .va-modal-body {
+      border-left-color: $color-primary-alt-dark;
+    }
+
+    .va-modal-title::before {
+      content: "\f05a";
+    }
+  }
+
+  &-error {
+    .va-modal-body {
+      border-left-color: $color-secondary-dark;
+    }
+
+    .va-modal-title::before {
+      color: $color-secondary-dark;
+      content: "\f06a"
+    }
+  }
+
+  &-success {
+    .va-modal-body {
+      border-left-color: $color-green;
+    }
+
+    .va-modal-title::before {
+      color: $color-green;
+      content: "\f00c";
+    }
+  }
+
+  &-warning {
+    .va-modal-body {
+      border-left-color: $color-gold;
+    }
+
+    .va-modal-title::before {
+      content: "\f071";
+    }
+  }
 }
 
 .va-modal-body {
@@ -189,7 +172,7 @@ button.va-modal-close {
   z-index: 9;
 
   &:hover {
-    background-color: inherit;
+    background-color: transparent;
     color: $color-base;
   }
 }

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -92,7 +92,6 @@
     }
 
     .va-modal-body {
-      background: $color-va-alert-bg;
       border-left-style: solid;
       border-left-width: 10px;
       padding: 2rem 4rem;

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -161,11 +161,11 @@
 
 button.va-modal-close {
   background-color: transparent;
-  color: $color-va-modal-close;
-  font-size: 2.5rem;
-  padding: 0.5rem 1rem;
+  color: $color-primary;
+  font-size: 2.25rem;
+  padding: 0;
   position: absolute;
-  margin: 0.25rem;
+  margin: 2rem;
   right: 0;
   top: 0;
   width: auto;
@@ -173,6 +173,11 @@ button.va-modal-close {
 
   &:hover {
     background-color: transparent;
-    color: $color-base;
+    color: $color-primary-darker;
+  }
+
+  &:active {
+    background-color: transparent;
+    color: $color-primary-darkest;
   }
 }


### PR DESCRIPTION
These changes will support alert-style modals (PR: department-of-veterans-affairs/vets-website#9596) as described in: department-of-veterans-affairs/vets.gov-team#16806.

Before these changes, passing a `status` prop to any `Modal` instances would result in a modal that appeared to be broken. The logic around handling different status types for modals was outdated especially after the redesign of the `AlertBox` component.

#### Before
> <img width="950" alt="screen shot 2019-02-18 at 9 32 57 am" src="https://user-images.githubusercontent.com/1067024/52957664-332d6200-3360-11e9-895e-42fb34a5a0df.png">

#### After
> <img width="609" alt="screen shot 2019-02-18 at 8 27 21 am" src="https://user-images.githubusercontent.com/1067024/52955637-2ce8b700-335b-11e9-9b65-de76c949369f.png">
